### PR TITLE
Add preserve indents task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -3,16 +3,28 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON('package.json')
     clean: [ 'docs' ]
-    replace: boldSyntaxElements:
-      options: patterns: [ {
-        match: /@@[a-zA-Z_0-9]*(\[[^\]]*\])*/g
-        replacement: (match) ->
-          '<b class="syntax-element">' + match.substring(2) + '</b>'
-      } ]
-      files: [ {
-        src:  '_site/index.html'
-        dest: 'docs/index.html'
-      } ]
+    replace:
+      boldSyntaxElements:
+        options: patterns: [ {
+          match: /@@[a-zA-Z_0-9]*(\[[^\]]*\])*/g
+          replacement: (match) ->
+            '<b class="syntax-element">' + match.substring(2) + '</b>'
+        } ]
+        files: [ {
+          src:  '_site/index.html'
+          dest: 'docs/index.html'
+        } ]
+      preserveIndents:
+        options:
+          patterns: [ {
+            match: /^\|([ ]){2,}/gm
+            replacement: (match) ->
+              '| ' + '&nbsp;'.repeat(match.substring(1).length - 1)
+          } ]
+        files: [ {
+          src:  '98.testing.md'
+          dest: '_tmp/98.testing.md'
+        } ]
     copy:
       docs:
         files: [ {
@@ -48,7 +60,7 @@ module.exports = (grunt) ->
   # Register the default tasks.
   grunt.registerTask 'default', [
     'clean'
-    'replace'
+    'replace:boldSyntaxElements'
     'copy'
   ]
   return

--- a/docs/assets/css/av1-spec.sass
+++ b/docs/assets/css/av1-spec.sass
@@ -43,29 +43,6 @@ table
       color: #000
       font-weight: normal
 
-table.syntax // Experimental
-  font-family: $monofont
-  font-size: 1em
-  margin-bottom: 1em
-  td, th
-    border: 1px solid #ccc
-    padding-left: .5em
-    padding-right: .5em
-  td code
-    color: #333
-    background-color: #fff
-    font-size: 1em
-    padding: 0
-  td:first-child
-    text-align: center
-  td:nth-child(2)
-    white-space: pre
-    width: 100%
-  th
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
-    color: #fff
-    background-color: #333
-
 b.syntax-element // Temporary: adjust syntax element columnar spacing
   padding-right: 1em
 
@@ -75,6 +52,30 @@ figure
     font-style: italic
     margin: 1em auto
 
+// Start Experimental
+table.syntax
+  width: 100%
+  font-size: 1em
+  margin-bottom: 1em
+  td, th
+    font-family: $monofont
+    border: 1px solid #ccc
+    padding-left: .5em
+    padding-right: .5em
+    line-height: 1.3
+  td code
+    color: #333
+    background-color: #fff
+    font-size: 1em
+    padding: 0
+  td:first-child
+    white-space: pre
+    //width: 100%
+  td:nth-child(2)
+    width: 20%
+  th
+    display: none
+// End Experimental
 
 // Rules that vary with viewport size
 //

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2017, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-12 06:51:52 -0700</em></p>
+<p><em>Last modified: 2018-03-12 07:10:48 -0700</em></p>
 
 <div class="alert alert-danger">
   <h2 class="no_toc no_count text-center" style="" id="draft-document"><strong>Draft Document</strong></h2>


### PR DESCRIPTION
... but don't yet apply.

This pattern will match all kramdown-formatted tables, though
it's meant for only syntax tables in kramdown format. This is
generally safe, but the pattern could be made more robust by
looking ahead for the occurrence of `{:.syntax }` before a
double newline.