### PR TITLE
Add jekyll build and local server as Grunt tasks

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -22,13 +22,14 @@ module.exports = (grunt) ->
               '| ' + '&nbsp;'.repeat(match.substring(1).length - 1)
           } ]
         files: [ {
-          src:  '98.testing.md'
-          dest: '_tmp/98.testing.md'
+          src:  '_site/98.testing.md'
+          dest: '_site/'
         } ]
     copy:
       docs:
         files: [ {
           expand: true
+          cwd: '_site'
           src: 'assets/**'
           dest: 'docs/'
         } ]
@@ -48,18 +49,28 @@ module.exports = (grunt) ->
       options:
         bundleExec: true
         skip_initial_build: false
-        verbose: true
+        verbose: false
+        dest: '_site'
       serve: options:
-        serve: true
-        dest: '.jekyll'
+        serve: false
+    connect: server: options:
+      hostname: '127.0.0.1'
+      port: 4000
+      base: '.'
+      keepalive: true
+      open: 'http://127.0.0.1:4000/docs/'
+      livereload: false # https://github.com/gruntjs/grunt-contrib-connect#livereload
   # Load the NPM tasks.
+  grunt.loadNpmTasks 'grunt-contrib-clean'
+  grunt.loadNpmTasks 'grunt-contrib-connect'
+  grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-jekyll'
   grunt.loadNpmTasks 'grunt-replace'
-  grunt.loadNpmTasks 'grunt-contrib-clean'
-  grunt.loadNpmTasks 'grunt-contrib-copy'
   # Register the default tasks.
   grunt.registerTask 'default', [
     'clean'
+    #'replace:preserveIndents'
+    'jekyll'
     'replace:boldSyntaxElements'
     'copy'
   ]

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -53,13 +53,22 @@ module.exports = (grunt) ->
         dest: '_site'
       serve: options:
         serve: false
-    connect: server: options:
-      hostname: '127.0.0.1'
-      port: 4000
-      base: '.'
-      keepalive: true
-      open: 'http://127.0.0.1:4000/docs/'
-      livereload: false # https://github.com/gruntjs/grunt-contrib-connect#livereload
+    connect:
+      local:
+        options:
+          hostname: '127.0.0.1'
+          port: 4000
+          base: '.'
+          keepalive: true
+          open: 'http://127.0.0.1:4000/docs/'
+          livereload: false
+      remote:
+        options:
+          hostname: '*'
+          port: 4000
+          base: '.'
+          keepalive: true
+          livereload: false
   # Load the NPM tasks.
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-connect'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -54,15 +54,22 @@ module.exports = (grunt) ->
       serve: options:
         serve: false
     connect:
+      remote:
+        options:
+          hostname: '*'
+          port: 4000
+          base: '.'
+          keepalive: true
+          livereload: false
       local:
         options:
-          hostname: '127.0.0.1'
+          hostname: '*'
           port: 4000
           base: '.'
           keepalive: true
           open: 'http://127.0.0.1:4000/docs/'
           livereload: false
-      remote:
+      nospawn:
         options:
           hostname: '*'
           port: 4000

--- a/README.md
+++ b/README.md
@@ -6,22 +6,21 @@ The specification document is built from plaintext section and subsection
 [Markdown] files (more specifically, [kramdown] files) using the [Jekyll] static
 site generator tool.
 
+The document build process employs a common [NodeJS]-based web development
+toolchain, requiring Node, [npm] (the Node package manager), and [GruntJS], a Node-based task runner.
 
-## Building Locally
-
-Contributors will want to preview their edits locally before submitting patches
-for review. Doing so requires a sane Ruby and rubygems environment. We use
-[rbenv] and [bundler] to "groom" the project environment and avoid conflicts.
-
-**Note** that all commands are to be run as an ordinary, unprivileged user.
+**Note:** As a general rule, the packages described below should be installed
+in user space, not at the system level -- in other words, **do not** install
+them as root or via `sudo`. An exception is Ruby development headers, which are
+usually needed to build Ruby and certain Ruby gems.
+{:.alert .alert-info }
 
 
 ### Ruby and rbenv
 
 This project currently depends on Ruby v2.4.1. Because your distro may lack this
 version -- or installing it may conflict with your system's installed version --
-first **[install rbenv]**, then install Ruby v2.4.1 within it (again, in
-userland).
+first **[install rbenv]**, then install Ruby v2.4.1 within it.
 
 ~~~~~ bash
 # list all available versions:
@@ -44,7 +43,7 @@ particular Ruby version. The rbenv project site maintains a
 
 ### Bundler
 
-Gem dependencies are managed by [bundler].
+Gem dependencies are managed with **[bundler]**.
 
 ~~~~~ bash
 $ gem install bundler
@@ -84,33 +83,15 @@ bundle install
 ~~~~~
 
 Bundler will set dependencies and install needed gems as listed in
-`Gemfile.lock`.
-
-**Note** that you may need Ruby development headers installed on your system
-for some gems to compile successfully.
+[`Gemfile.lock`].
 
 
-### Build and Preview Locally with Jekyll
+### NodeJS, npm and GruntJS
 
-~~~~~ bash
-bundle exec jekyll serve
-~~~~~
+Follow **[these instructions]** for installing NodeJS and npm.
 
-This will build the document and launch a local webserver at
-`http://127.0.0.1:4000/av1-spec/` (by default). Jekyll will also watch the
-the filesystem for changes and rebuild the document as needed. Reload your
-browser tab to view any changes you've made.
-
-
-### Notes on NPM and Grunt
-
-_These steps are not critically necessary for working on the document. Rather,
-they apply cosmetic changes to the HTML output on a postproc basis._
-
-The specification document requires a bit of arbitrary text manipulation that
-can't be done with Jekyll alone. To automate these needs we turn to [GruntJS], a
-Node-based task runner. The following assumes you have already installed
-[NodeJS] and [npm], the Node package manager.
+Next -- from the project directory -- update npm, install the grunt package,
+and install the project's Node dependencies:
 
 ~~~~~ bash
 ## Update npm globally
@@ -127,15 +108,39 @@ cd av1-spec
 npm install
 ~~~~~
 
-To transform the Jekyll-generated HTML file (`_site/index.html`), run `grunt` in
-the project directory. This will apply the text transformations described in
-Grunt's `replace` task (see `Gruntfile`) and will write the output to
-`docs/index.html`.
 
-Currently this method is used to "bold" the names of syntax elements within
-syntax tables. For example, the tokenized string `@@syntax_element` will be
-replaced with `<b>syntax_element</b>`. This reduces the clutter of HTML elements
-within the source text files.
+### Grunt Tasks
+
+Building the document is done via Grunt tasks, configured in the CoffeeScript
+file [`Gruntfile.coffee`].
+
+There are tasks to
+
+  * clean output directories,
+  * perform some automated text transformations on the content files,
+  * build the document with Jekyll,
+  * and copy output files to the correct directories for serving and viewing.
+
+These tasks are invoked in turn by the Grunt default task:
+
+~~~~~
+$ grunt
+~~~~~
+
+There is also a task that starts a local web server, and launches the document
+in your web browser:
+
+~~~~~
+$ grunt connect:local
+~~~~~
+
+The document will be viewable at <http://127.0.0.1:4000/docs/>
+
+If you'd rather not launch a browser window, use:
+
+~~~~~
+$ grunt connect:nospawn
+~~~~~
 
 
 [draft]: https://aomediacodec.github.io/av1-spec/
@@ -148,3 +153,6 @@ within the source text files.
 [GruntJS]: https://gruntjs.com/
 [NodeJS]: https://nodejs.org/
 [npm]: https://www.npmjs.org/
+[`Gemfile.lock`]: https://github.com/AOMediaCodec/av1-spec/blob/master/Gemfile.lock
+[these instructions]: https://www.taniarascia.com/how-to-install-and-use-node-js-and-npm-mac-and-windows/
+[`Gruntfile.coffee`]: https://github.com/AOMediaCodec/av1-spec/blob/master/Gruntfile.coffee

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>{{ site.title }}</title>
-  <link rel="stylesheet" href="{{ 'assets/css/av1-spec.css' | relative_url }}">
-  <link rel="stylesheet" href="{{ 'assets/css/bootstrap.min.css' | relative_url }}">
+  <link rel="stylesheet" href="assets/css/av1-spec.css">
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css">
   <link rel="apple-touch-icon" sizes="57x57" href="assets/images/icons/apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="assets/images/icons/apple-icon-60x60.png">
   <link rel="apple-touch-icon" sizes="72x72" href="assets/images/icons/apple-icon-72x72.png">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>AV1 Bitstream &amp; Decoding Process Specification</title>
-  <link rel="stylesheet" href="/av1-spec/assets/css/av1-spec.css">
-  <link rel="stylesheet" href="/av1-spec/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/av1-spec.css">
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css">
   <link rel="apple-touch-icon" sizes="57x57" href="assets/images/icons/apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="assets/images/icons/apple-icon-60x60.png">
   <link rel="apple-touch-icon" sizes="72x72" href="assets/images/icons/apple-icon-72x72.png">
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2017, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-12 07:10:48 -0700</em></p>
+<p><em>Last modified: 2018-03-12 12:30:01 -0700</em></p>
 
 <div class="alert alert-danger">
   <h2 class="no_toc no_count text-center" style="" id="draft-document"><strong>Draft Document</strong></h2>
@@ -2865,7 +2865,7 @@ each of the syntax elements is presented in <a href="#syntax-structures-semantic
             <b class="syntax-element">display_frame_id</b>                                                 f(idLen)
         }
         CurrentVideoFrame += 1
-        film_grain_params( )
+        load_grain_params( frame_to_show_map_idx )
         return
     }
     <b class="syntax-element">frame_type</b>                                                               f(2)
@@ -3033,6 +3033,11 @@ each of the syntax elements is presented in <a href="#syntax-structures-semantic
     <b class="syntax-element">reduced_tx_set</b>                                                           f(1)
     global_motion_params( )
     if ( show_frame ) {
+        showable_frame = 0
+    } else {
+        <b class="syntax-element">showable_frame</b>                                                       f(1)
+    }
+    if ( show_frame || showable_frame) {
         film_grain_params( )
     }
 }
@@ -3791,6 +3796,7 @@ However, these fractional bits will be discarded during the Setup Zero MV proces
     }
     <b class="syntax-element">apply_grain</b>                                                              f(1)
     if ( !apply_grain ) {
+        reset_grain_params()
         return
     }
     <b class="syntax-element">grain_seed</b>                                                               f(16)
@@ -3799,6 +3805,10 @@ However, these fractional bits will be discarded during the Setup Zero MV proces
     else
         update_grain = 1
     if ( !update_grain ) {
+        <b class="syntax-element">film_grain_params_ref_idx</b>                                            f(3)
+        tempGrainSeed = grain_seed
+        load_grain_params( film_grain_params_ref_idx )
+        grain_seed = tempGrainSeed
         return
     }
     <b class="syntax-element">num_y_points</b>                                                             f(4)
@@ -7617,6 +7627,16 @@ encoding.</p>
 <p><strong>reduced_tx_set</strong> equal to 1 specifies that the frame is restricted to a
 reduced subset of the full set of transform types.</p>
 
+<p><strong>showable_frame</strong> equal to 1 specifies that the frame may be displayed using the show_existing_frame mechanism.
+showable_frame equal to 0 specifies that this frame may not be displayed using the show_existing_frame mechanism.</p>
+
+<p>It is a requirement of bitstream conformance that when show_existing_frame is used to show a previous frame,
+that the value of showable_frame for the previous frame was equal to 1.</p>
+
+<p>It is a requirement of bitstream conformance that a particular showable frame is displayed via the show_existing_frame mechanism at most once.</p>
+
+<p class="alert alert-info"><strong>Note:</strong> This requirement also forbids storing a frame into multiple reference buffers and then using show_existing_frame for each buffer.</p>
+
 <p><strong>setup_past_independence</strong> is a function call that indicates that this frame
 can be decoded without dependence on previous coded frames. When this function
 is invoked the following takes place:</p>
@@ -8437,17 +8457,24 @@ the range 0 to n-1.</p>
 <p><strong>apply_grain</strong> equal to 1 specifies that film grain should be added to this frame.
 apply_grain equal to 0 specifies that film grain should not be added.</p>
 
+<p><strong>reset_grain_params()</strong> is a function call that indicates that all the syntax elements normally read in film_grain_params should be set equal to 0.</p>
+
 <p><strong>grain_seed</strong> specifies the starting value for the pseudo-random numbers used during film grain synthesis.</p>
 
 <p><strong>update_grain</strong> equal to 1 means that a new set of parameters should be sent.
 update_grain equal to 0 means that the previous set of parameters should be used.</p>
 
-<p>It is a requirement of bitstream conformance that if update_grain is set to 0, then
-there must have been a previous frame in decoding order for which update_grain was
-set to 1 (this ensures that the parameters are always defined before being used).</p>
+<p><strong>film_grain_params_ref_idx</strong> indicates which reference frame contains the film grain parameters to be used for this frame.</p>
 
-<p>It is a requirement of bitstream conformance that if update_grain is coded in the bitstream and FrameIsIntra is equal to 1,
-then update_grain is equal to 1 (this ensures that intra frames are independently decodable).</p>
+<p><strong>load_grain_params(idx)</strong> is a function call that indicates that all the syntax elements normally
+read in film_grain_params should be set equal to the values stored in an area of memory indexed by idx.</p>
+
+<p>It is a requirement of bitstream conformance that load_grain_params(idx) is invoked, then
+there must have been a previous frame in decoding order for which save_grain_params(idx) was
+invoked (this ensures that the parameters are always defined before being used).</p>
+
+<p><strong>tempGrainSeed</strong> is a temporary variable that is used to avoid losing the value of grain_seed when load_grain_params is called.
+When update_grain is equal to 0, a previous set of parameters should be used for everything except grain_seed.</p>
 
 <p><strong>num_y_points</strong> specifies the number of points for the piece-wise linear
 scaling function of the luma component.</p>
@@ -18627,6 +18654,9 @@ for col = 0..MiCols-1.</p>
   <li>
     <p>The function save_cdfs( i ) is invoked (see below).</p>
   </li>
+  <li>
+    <p>If film_grain_params_present is equal to 1, the function save_grain_params( i ) is invoked (see below).</p>
+  </li>
 </ul>
 
 <p>For each value of i from 0 to NUM_REF_FRAMES - 1, the following applies
@@ -18643,6 +18673,9 @@ When this function is invoked the following takes place:</p>
 <ul>
   <li>A copy of each CDF array mentioned in the semantics for setup_past_independence is saved in an area of memory indexed by ctx.</li>
 </ul>
+
+<p>save_grain_params( i ) is a function call that indicates that all the syntax elements that can be
+read in film_grain_params should be saved into an area of memory indexed by i.</p>
 
 <p class="alert alert-info"><strong>Note:</strong> Although this process stores all the motion vectors, only the values where row and col are both odd will be used again.</p>
 
@@ -32136,6 +32169,10 @@ This can be useful for encoder implementations that want to leave a fixed amount
       </tr>
       <tr>
         <td>film_grain_noise</td>
+        <td> </td>
+      </tr>
+      <tr>
+        <td>film_grain_noise_showex</td>
         <td> </td>
       </tr>
       <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2017, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-12 12:30:01 -0700</em></p>
+<p><em>Last modified: 2018-03-13 17:40:46 -0700</em></p>
 
 <div class="alert alert-danger">
   <h2 class="no_toc no_count text-center" style="" id="draft-document"><strong>Draft Document</strong></h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,16 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -96,6 +106,21 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -137,6 +162,24 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "1.3.2",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "connect-livereload": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
+      "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
+      "dev": true
+    },
     "cson-parser": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
@@ -160,6 +203,45 @@
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -170,6 +252,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
       "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter2": {
@@ -189,6 +277,21 @@
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
     },
     "findup-sync": {
       "version": "0.1.3",
@@ -227,6 +330,12 @@
           }
         }
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -397,6 +506,31 @@
         }
       }
     },
+    "grunt-contrib-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-1.0.2.tgz",
+      "integrity": "sha1-XPkzuRpnOGBEJzwLJERgPNmIebo=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "connect": "3.6.6",
+        "connect-livereload": "0.5.4",
+        "http2": "3.3.7",
+        "morgan": "1.9.0",
+        "opn": "4.0.2",
+        "portscanner": "1.2.0",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
     "grunt-contrib-copy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
@@ -524,6 +658,32 @@
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        }
+      }
+    },
+    "http2": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
+      "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
@@ -568,6 +728,27 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
     "minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
@@ -578,6 +759,31 @@
         "sigmund": "1.0.1"
       }
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "dev": true,
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -586,6 +792,27 @@
       "requires": {
         "abbrev": "1.1.1"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -596,16 +823,70 @@
         "wrappy": "1.0.2"
       }
     },
+    "opn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "portscanner": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
+      "integrity": "sha1-sUu9olfRTDEPqcwJaCrwLUCWGAI=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "resolve": {
@@ -620,6 +901,74 @@
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.2",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -630,6 +979,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "strip-ansi": {
@@ -666,6 +1021,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-jekyll": "^0.4.6",
     "grunt-replace": "^1.0.1"


### PR DESCRIPTION
Previously we relied on `jekyll serve` (implicitly `jekyll serve --watch`) to both do the jekyll build and
launch a development web server.

This substitutes Grunt tasks for those functions, using `grunt-jekyll` and `grunt-contrib-connect` -- rendering the README incorrect for now. This improvement is needed so that text transforms can be applied in the correct order.

The default Grunt task now does:

1. `clean` -- Purge output directories
2. `jekyll` -- Does the jekyll build only (no serve, no watch), outputs to `_site/`
3. `replace` -- Applies `boldSyntaxElements` to the generated `_site/index.html`
4. `copy` -- Copies needed files to `docs/`, which serves as the DOCROOT for gh-pages

A development server can then be launched with `grunt connect`, which spawns a browser tab at `docs/`. The `connect` task might be added at the end of the `default` meta-task, but it's not strictly necessary and perhaps undesirable.

Also added `replace:preserveIndents`, but commented, because it's strangely not finding matches. TODO