### PR TITLE
Implement preserveIndents replacement task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -22,8 +22,8 @@ module.exports = (grunt) ->
               '| ' + '&nbsp;'.repeat(match.substring(1).length - 1)
           } ]
         files: [ {
-          src:  '_site/98.testing.md'
-          dest: '_site/'
+          src:  '98.testing.md'
+          dest: '_tmp/'
         } ]
     copy:
       docs:
@@ -50,6 +50,7 @@ module.exports = (grunt) ->
         bundleExec: true
         skip_initial_build: false
         verbose: false
+        src: '.'
         dest: '_site'
       serve: options:
         serve: false
@@ -85,7 +86,7 @@ module.exports = (grunt) ->
   # Register the default tasks.
   grunt.registerTask 'default', [
     'clean'
-    #'replace:preserveIndents'
+    'replace:preserveIndents'
     'jekyll'
     'replace:boldSyntaxElements'
     'copy'

--- a/_layouts/pdf.html
+++ b/_layouts/pdf.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{ site.title }}</title>
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/av1-spec.css">
+  <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
+  <!-- Include all compiled plugins (below), or include individual files as needed -->
+  <script src="assets/js/bootstrap.min.js"></script>
+</head>
+
+<body>
+{{ content }}
+</body>
+</html>

--- a/_layouts/web.html
+++ b/_layouts/web.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>{{ site.title }}</title>
-  <link rel="stylesheet" href="assets/css/av1-spec.css">
   <link rel="stylesheet" href="assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/av1-spec.css">
   <link rel="apple-touch-icon" sizes="57x57" href="assets/images/icons/apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="assets/images/icons/apple-icon-60x60.png">
   <link rel="apple-touch-icon" sizes="72x72" href="assets/images/icons/apple-icon-72x72.png">

--- a/_tmp/98.testing.md
+++ b/_tmp/98.testing.md
@@ -1,0 +1,44 @@
+* * *
+
+**This area is for format testing, and not part of the AV1 bitstream document.**
+{:.alert .alert-danger style="margin-top: 120px;"}
+
+
+**Small table example**
+
+| --------------------------------------------------------- | ---------------- |
+| obu_header() {                                            | **Type**
+| &nbsp;&nbsp;&nbsp;&nbsp;@@obu_forbidden_bit                                   | f(1)
+| &nbsp;&nbsp;&nbsp;&nbsp;@@obu_type                                            | f(4)
+| &nbsp;&nbsp;&nbsp;&nbsp;@@obu_reserved_2bits                                  | f(2)
+| &nbsp;&nbsp;&nbsp;&nbsp;@@obu_extension_flag                                  | f(1)
+| &nbsp;&nbsp;&nbsp;&nbsp;if ( obu_extension_flag == 1 )
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;obu_extension_header()
+| }
+{:.syntax }
+
+
+**Long lines example**
+
+| --------------------------------------------------------- | ---------------- |
+| read_delta_qindex( ) {                                    | **Type**
+| &nbsp;&nbsp;&nbsp;&nbsp;sbSize = use_128x128_superblock ? BLOCK_128X128 : BLOCK_64X64
+| &nbsp;&nbsp;&nbsp;&nbsp;if ( MiSize == sbSize && skip )
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return
+| &nbsp;&nbsp;&nbsp;&nbsp;if ( ReadDeltas ) {
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@@delta_q_abs                                     | S()
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if ( delta_q_abs == DELTA_Q_SMALL ) {
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@@delta_q_rem_bits                            | L(3)
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delta_q_rem_bits++
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@@delta_q_abs_bits                            | L(delta_q_rem_bits)
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delta_q_abs = delta_q_abs_bits + (1 << delta_q_rem_bits) + 1
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (delta_q_abs) {
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@@delta_q_sign_bit                            | L(1)
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reducedDeltaQIndex = delta_q_sign_bit ? -delta_q_abs : delta_q_abs
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CurrentQIndex = Clip3(1, 255, CurrentQIndex + (reducedDeltaQIndex << delta_q_res))
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}
+| &nbsp;&nbsp;&nbsp;&nbsp;}
+| }
+{:.syntax }
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>AV1 Bitstream &amp; Decoding Process Specification</title>
-  <link rel="stylesheet" href="assets/css/av1-spec.css">
   <link rel="stylesheet" href="assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/av1-spec.css">
   <link rel="apple-touch-icon" sizes="57x57" href="assets/images/icons/apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="assets/images/icons/apple-icon-60x60.png">
   <link rel="apple-touch-icon" sizes="72x72" href="assets/images/icons/apple-icon-72x72.png">
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2017, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-13 17:40:46 -0700</em></p>
+<p><em>Last modified: 2018-03-16 11:43:01 -0700</em></p>
 
 <div class="alert alert-danger">
   <h2 class="no_toc no_count text-center" style="" id="draft-document"><strong>Draft Document</strong></h2>
@@ -32535,27 +32535,27 @@ sRGB.</p>
       <td><strong>Type</strong></td>
     </tr>
     <tr>
-      <td><b class="syntax-element">obu_forbidden_bit</b></td>
+      <td>    <b class="syntax-element">obu_forbidden_bit</b></td>
       <td>f(1)</td>
     </tr>
     <tr>
-      <td><b class="syntax-element">obu_type</b></td>
+      <td>    <b class="syntax-element">obu_type</b></td>
       <td>f(4)</td>
     </tr>
     <tr>
-      <td><b class="syntax-element">obu_reserved_2bits</b></td>
+      <td>    <b class="syntax-element">obu_reserved_2bits</b></td>
       <td>f(2)</td>
     </tr>
     <tr>
-      <td><b class="syntax-element">obu_extension_flag</b></td>
+      <td>    <b class="syntax-element">obu_extension_flag</b></td>
       <td>f(1)</td>
     </tr>
     <tr>
-      <td>if ( obu_extension_flag == 1 )</td>
+      <td>    if ( obu_extension_flag == 1 )</td>
       <td> </td>
     </tr>
     <tr>
-      <td>obu_extension_header()</td>
+      <td>        obu_extension_header()</td>
       <td> </td>
     </tr>
     <tr>
@@ -32574,71 +32574,71 @@ sRGB.</p>
       <td><strong>Type</strong></td>
     </tr>
     <tr>
-      <td>sbSize = use_128x128_superblock ? BLOCK_128X128 : BLOCK_64X64</td>
+      <td>    sbSize = use_128x128_superblock ? BLOCK_128X128 : BLOCK_64X64</td>
       <td> </td>
     </tr>
     <tr>
-      <td>if ( MiSize == sbSize &amp;&amp; skip )</td>
+      <td>    if ( MiSize == sbSize &amp;&amp; skip )</td>
       <td> </td>
     </tr>
     <tr>
-      <td>return</td>
+      <td>        return</td>
       <td> </td>
     </tr>
     <tr>
-      <td>if ( ReadDeltas ) {</td>
+      <td>    if ( ReadDeltas ) {</td>
       <td> </td>
     </tr>
     <tr>
-      <td><b class="syntax-element">delta_q_abs</b></td>
+      <td>        <b class="syntax-element">delta_q_abs</b></td>
       <td>S()</td>
     </tr>
     <tr>
-      <td>if ( delta_q_abs == DELTA_Q_SMALL ) {</td>
+      <td>        if ( delta_q_abs == DELTA_Q_SMALL ) {</td>
       <td> </td>
     </tr>
     <tr>
-      <td><b class="syntax-element">delta_q_rem_bits</b></td>
+      <td>            <b class="syntax-element">delta_q_rem_bits</b></td>
       <td>L(3)</td>
     </tr>
     <tr>
-      <td>delta_q_rem_bits++</td>
+      <td>            delta_q_rem_bits++</td>
       <td> </td>
     </tr>
     <tr>
-      <td><b class="syntax-element">delta_q_abs_bits</b></td>
+      <td>            <b class="syntax-element">delta_q_abs_bits</b></td>
       <td>L(delta_q_rem_bits)</td>
     </tr>
     <tr>
-      <td>delta_q_abs = delta_q_abs_bits + (1 « delta_q_rem_bits) + 1</td>
+      <td>            delta_q_abs = delta_q_abs_bits + (1 « delta_q_rem_bits) + 1</td>
       <td> </td>
     </tr>
     <tr>
-      <td>}</td>
+      <td>        }</td>
       <td> </td>
     </tr>
     <tr>
-      <td>if (delta_q_abs) {</td>
+      <td>        if (delta_q_abs) {</td>
       <td> </td>
     </tr>
     <tr>
-      <td><b class="syntax-element">delta_q_sign_bit</b></td>
+      <td>            <b class="syntax-element">delta_q_sign_bit</b></td>
       <td>L(1)</td>
     </tr>
     <tr>
-      <td>reducedDeltaQIndex = delta_q_sign_bit ? -delta_q_abs : delta_q_abs</td>
+      <td>            reducedDeltaQIndex = delta_q_sign_bit ? -delta_q_abs : delta_q_abs</td>
       <td> </td>
     </tr>
     <tr>
-      <td>CurrentQIndex = Clip3(1, 255, CurrentQIndex + (reducedDeltaQIndex « delta_q_res))</td>
+      <td>            CurrentQIndex = Clip3(1, 255, CurrentQIndex + (reducedDeltaQIndex « delta_q_res))</td>
       <td> </td>
     </tr>
     <tr>
-      <td>}</td>
+      <td>        }</td>
       <td> </td>
     </tr>
     <tr>
-      <td>}</td>
+      <td>    }</td>
       <td> </td>
     </tr>
     <tr>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: web
 title: AV1 Bitstream &amp; Decoding Process Specification
 version_date: Released 2017-xx-xx
 ---
@@ -44,7 +44,7 @@ version_date: Released 2017-xx-xx
 
 {% include_relative bibliography.md %}
 
-{% include_relative 98.testing.md %}
+{% include_relative _tmp/98.testing.md %}
 
 {% comment %}
 {% include_relative 99.function-reference-links.md %}


### PR DESCRIPTION
Jekyll collapses leading whitespace (indentation) in table cells. This change replaces indentation spaces with `&nbsp;` in the testing file `98.testing.md`, preserving indents.

Can be discretely applied to any `*.md` whose syntax tables are formatted in kramdown style.

Also renamed `page.html` layout to `web.html` and added a variant `pdf.html` for future PDF generation.