### PR TITLE
Add PDF generation basics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 _site/
+_tmp/
 _build/
 .sass-cache/
 node_modules/
 .jekyll-metadata
+docs/av1-spec.html
+docs/av1-spec.pdf
+docs/assets/css/av1-spec-print.css

--- a/10.additional.tables.md
+++ b/10.additional.tables.md
@@ -2252,6 +2252,7 @@ Default_Filter_Intra_Cdf[ BLOCK_SIZES ][ 3 ] = {
 }
 ~~~~~
 
+~~~~~ c
 Default_Segment_Id_Cdf[ SEGMENT_ID_CONTEXTS ][ MAX_SEGMENTS + 1 ] = {
   { 5622, 7893, 16093, 18233, 27809, 28373, 32533, 32768, 0 },
   { 14274, 18230, 22557, 24935, 29980, 30851, 32344, 32768, 0 },

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,10 +10,10 @@ module.exports = (grunt) ->
           replacement: (match) ->
             '<b class="syntax-element">' + match.substring(2) + '</b>'
         } ]
-        files: [ {
-          src:  '_site/index.html'
-          dest: 'docs/index.html'
-        } ]
+        files: [
+          { src:  '_site/index.html', dest: 'docs/index.html' },
+          { src:  '_site/pdf.html', dest: 'docs/av1-spec.html' }
+        ]
       preserveIndents:
         options:
           patterns: [ {
@@ -77,12 +77,17 @@ module.exports = (grunt) ->
           base: '.'
           keepalive: true
           livereload: false
+    exec:
+      pdf:
+        cmd: 'prince docs/av1-spec.html -o docs/av1-spec.pdf'
+        stderr: false
   # Load the NPM tasks.
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-connect'
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-jekyll'
   grunt.loadNpmTasks 'grunt-replace'
+  grunt.loadNpmTasks('grunt-exec');
   # Register the default tasks.
   grunt.registerTask 'default', [
     'clean'

--- a/_layouts/pdf.html
+++ b/_layouts/pdf.html
@@ -5,6 +5,7 @@
   <title>{{ site.title }}</title>
   <link rel="stylesheet" href="assets/css/bootstrap.min.css">
   <link rel="stylesheet" href="assets/css/av1-spec.css">
+  <link rel="stylesheet" href="assets/css/av1-spec-print.css" media="print">
   <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>

--- a/assets/css/av1-spec-print.sass
+++ b/assets/css/av1-spec-print.sass
@@ -1,0 +1,61 @@
+---
+---
+// av1-spec-print.sass
+
+body
+  //width: 100%
+  //margin: .5in
+  padding: 0
+  font-size: 10pt
+  color: #000
+  background-color: #fff
+@page
+  size: letter portrait
+  margin: .75in .5in
+  @top-right
+    content: string(doctitle)
+    font-size: 10pt
+    font-family: Arial, sans-serif
+    font-style: italic
+    color: #333
+  @top-left
+    //
+  @bottom-right
+    content: "Page " counter(page) " of " counter(pages)
+    font-size: 10pt
+    font-family: Arial, sans-serif
+    font-style: italic
+    color: #333
+  @bottom-left
+    content: "Section: " string(sectiontitle)
+    font-size: 10pt
+    font-family: Arial, sans-serif
+    font-style: italic
+    color: #333
+  @prince-overlay
+    color: rgba(255, 0, 0, 0.2)
+    content: "Draft Document \A Do Not Use"
+    font-size: 72pt
+    font-weight: bold
+    font-family: Arial, sans-serif
+    transform: rotate(315deg)
+    white-space: pre
+//@page:first
+//  margin-top: 10cm
+//  @bottom
+//    content: normal
+h1
+  string-set: doctitle content()
+h2
+  string-set: sectiontitle content()
+h1, h2, h3, dt
+  page-break-after: avoid
+dd
+  page-break-before: avoid
+img, table, figure
+  max-width: 100% !important
+  page-break-inside: avoid
+pre
+  border: 0
+.noprint
+  display: none !important

--- a/assets/css/av1-spec.sass
+++ b/assets/css/av1-spec.sass
@@ -1,8 +1,7 @@
 ---
 ---
-/*
- * style.sass
- */
+//av1-spec.sass
+
 @import url('https://fonts.googleapis.com/css?family=Inconsolata')
 
 $monofont: 'Inconsolata', monospace

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2017, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-16 11:59:07 -0700</em></p>
+<p><em>Last modified: 2018-03-16 19:52:56 -0700</em></p>
 
 <div class="alert alert-danger">
   <h2 class="no_toc no_count text-center" style="" id="draft-document"><strong>Draft Document</strong></h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,6 +541,12 @@
         "file-sync-cmp": "0.1.1"
       }
     },
+    "grunt-exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
+      "integrity": "sha512-cgAlreXf3muSYS5LzW0Cc4xHK03BjFOYk0MqCQ/MZ3k1Xz2GU7D+IAJg4UKicxpO+XdONJdx/NJ6kpy2wI+uHg==",
+      "dev": true
+    },
     "grunt-jekyll": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/grunt-jekyll/-/grunt-jekyll-0.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "^1.0.0",
+    "grunt-exec": "^3.0.0",
     "grunt-jekyll": "^0.4.6",
     "grunt-replace": "^1.0.1"
   },

--- a/pdf.md
+++ b/pdf.md
@@ -31,5 +31,4 @@ version_date: Released 2017-xx-xx
 {% include_relative _tmp/98.testing.md %}
 
 {% comment %}
-{% include_relative 99.function-reference-links.md %}
 {% endcomment %}


### PR DESCRIPTION
Adds an alternate template, Markdown file, CSS and Grunt task
for generating the document in PDF, using PrinceXML.

https://www.princexml.com/

Quite a few refinements still to do, but it appears this will
work well.