### PR TITLE
Break pages before section heading (H2).

### DIFF
--- a/assets/css/av1-spec-print.sass
+++ b/assets/css/av1-spec-print.sass
@@ -71,9 +71,13 @@ div#cover
 h1
   string-set: doctitle content()
 h2
+  page-break-before: always
   string-set: sectiontitle content()
 h1, h2, h3, dt
   page-break-after: avoid
+h2 + table,
+h2 + pre.syntax
+  page-break-before: avoid
 dd
   page-break-before: avoid
 img, table, figure

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2018, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-19 12:57:42 -0700</em></p>
+<p><em>Last modified: 2018-03-19 13:15:02 -0700</em></p>
 
 <div id="draft-legend" class="alert alert-danger">
 
@@ -2261,7 +2261,7 @@ and Round2Signed) are defined as follows:</p>
 
 <p>An equivalent definition (using the pseudo-code notation introduced in the following section) is:</p>
 
-<pre><code class="language-c">FloorLog2( n ) {
+<pre><code class="language-c">FloorLog2( x ) {
   s = 0
   while (x != 0) {
     x = x &gt;&gt; 1
@@ -2504,7 +2504,7 @@ comparison):</p>
     <tr>
       <th style="text-align: center">Value</th>
       <th style="text-align: center">Full binary encoding</th>
-      <th style="text-align: center">U(n) encoding</th>
+      <th style="text-align: center">ns(n) encoding</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Follow print convention, and keeps section name in
page footers synced.

Cosmetically awkward in cases where a multi-page
block immediately follows H2, as this `page-break-before`
rule conflicts with `page-break-inside: avoid` on tables,
images, etc. Worth a closer look.