### PR TITLE
Handle print TOC differently than web

### DIFF
--- a/00.toc-print.md
+++ b/00.toc-print.md
@@ -1,0 +1,6 @@
+
+## Contents
+{:.no_toc .no_count}
+
+* TOC
+{:toc}

--- a/00.toc-web.md
+++ b/00.toc-web.md
@@ -7,7 +7,7 @@ $(document).ready(function() {
         if (content.indexOf("Annex") == 0) {
             var annexID = content.substring(6, 7)
             var items = $(this).find("li").add(this);
-            
+
             items.attr("data-annexid", annexID);
             items.addClass("annex");
         }

--- a/assets/css/av1-spec-print.sass
+++ b/assets/css/av1-spec-print.sass
@@ -64,9 +64,20 @@ body
   @bottom-left
     content: normal
 
-div#cover
+// End Cover page
+
+// Front matter
+
+div#frontmatter
+  page: frontmatter
+
+@page frontmatter
   page-break-after: always
   counter-reset: page
+  @bottom-right
+    content: normal
+
+// End front matter
 
 h1
   string-set: doctitle content()

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2018, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-19 13:52:47 -0700</em></p>
+<p><em>Last modified: 2018-03-19 14:47:25 -0700</em></p>
 
 <div id="draft-legend" class="alert alert-danger">
 
@@ -73,7 +73,7 @@ $(document).ready(function() {
         if (content.indexOf("Annex") == 0) {
             var annexID = content.substring(6, 7)
             var items = $(this).find("li").add(this);
-            
+
             items.attr("data-annexid", annexID);
             items.addClass("annex");
         }

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ version_date: Released 2017-xx-xx
 {% include_relative 00.draft-legend.md %}
 </div>
 {% include_relative 00.abstract.md %}
-{% include_relative 00.toc.md %}
+{% include_relative 00.toc-web.md %}
 {% include_relative 01.scope.md %}
 {% include_relative 02.terms.md %}
 {% include_relative 03.symbols.md %}

--- a/pdf.md
+++ b/pdf.md
@@ -5,19 +5,22 @@ version_date: Released 2017-xx-xx
 ---
 
 {% include_relative section.links.md %}
-<div id="cover" markdown="1">
-{% include_relative 00.title.md %}
-{% include_relative 00.version.md %}
+<div id="frontmatter">
+  <div id="cover" markdown="1">
+  {% include_relative 00.title.md %}
+  {% include_relative 00.version.md %}
+  </div>
+  <div id="draft-legend" class="alert alert-danger" markdown="1">
+  {% include_relative 00.draft-legend.md %}
+  </div>
+  <div id="abstract" markdown="1">
+  {% include_relative 00.abstract.md %}
+  </div>
+  <div id="toc" markdown="1">
+  {% include_relative 00.toc-print.md %}
+  </div>
 </div>
-<div id="draft-legend" class="alert alert-danger" markdown="1">
-{% include_relative 00.draft-legend.md %}
-</div>
-<div id="abstract" markdown="1">
-{% include_relative 00.abstract.md %}
-</div>
-<div id="toc" markdown="1">
-{% include_relative 00.toc.md %}
-</div>
+<div style="counter-reset: page"></div>
 {% include_relative 01.scope.md %}
 {% include_relative 02.terms.md %}
 {% include_relative 03.symbols.md %}


### PR DESCRIPTION
  * Render the print table of contents in full
  * Reset page counter at Scope section
  * Suppress numbering for pages within #frontmatter

Possible enhancement: number frontmatter pages with l.c. Roman numerals