### PR TITLE
[PDF] Change inline code color

### DIFF
--- a/assets/css/av1-spec-print.sass
+++ b/assets/css/av1-spec-print.sass
@@ -105,4 +105,6 @@ pre
   display: none !important
 a
   color: #0a3f77
+code
+  color: #1c561e
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 
 <p><em>Copyright 2018, The <a href="http://aomedia.org/">Alliance for Open Media</a></em></p>
 
-<p><em>Last modified: 2018-03-20 12:16:14 -0700</em></p>
+<p><em>Last modified: 2018-03-20 12:36:01 -0700</em></p>
 
 <div id="draft-legend" class="alert alert-danger">
 


### PR DESCRIPTION
Change default Bootstrap red for code spans (not code blocks) to a dark green (#1c561e).