### PR TITLE
CfL uses reconstructed luma samples

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -3992,8 +3992,8 @@ i = 0..h-1 and j = 0..w-1.
 
 #### Predict Chroma From Luma Process
 
-The chroma from luma process uses luma predicted samples to form a prediction for the chroma samples.
-The high frequencies are taken from the luma prediction and combined with DC predicted chroma samples.
+The chroma from luma process uses reconstructed luma samples to form a prediction for the chroma samples.
+The high frequencies are taken from the reconstructed luma samples and combined with DC predicted chroma samples.
 
 The inputs to this process are:
 


### PR DESCRIPTION
CfL uses reconstructed luma samples not predicted luma samples.

Another issue is that the DC predicted chroma samples might also be considered as input.