### PR TITLE
[cfl] Luma average is rounded, not truncated.

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -4048,7 +4048,7 @@ for ( i = 0; i < h; i++ ) {
         lumaAvg += v
     }
 }
-lumaAvg >>= Tx_Width_Log2[ txSz ] + Tx_Height_Log2[ txSz ]
+lumaAvg = Round2( lumaAvg, Tx_Width_Log2[ txSz ] + Tx_Height_Log2[ txSz ] )
 ~~~~~
 
 The predicted chroma pixels are specified as:


### PR DESCRIPTION
Spec changes to match patch 14520

This fixes issue #51