### PR TITLE
[CFL] Don't predict CfL twice

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -2895,11 +2895,6 @@ is_scaled( refFrame ) {
 |                     else if ( interintra_mode == II_V_PRED ) mode = V_PRED
 |                     else if ( interintra_mode == II_H_PRED ) mode = H_PRED
 |                     else mode = SMOOTH_PRED
-|                 } else {
-|                     mode = DC_PRED
-|                 }
-|
-|                 if ( IsInterIntra \|\| IsCFL ) {
 |                     predict_intra( plane, baseX, baseY,
 |                         plane == 0 ? AvailL : AvailLChroma,
 |                         plane == 0 ? AvailU : AvailUChroma,
@@ -2911,6 +2906,8 @@ is_scaled( refFrame ) {
 |                                     [ ( subBlockMiCol \>\> subX ) - 1 ],
 |                         mode,
 |                         log2W, log2H )
+|                 } else {
+|                     mode = DC_PRED
 |                 }
 |
 |                 if ( is_inter ) {


### PR DESCRIPTION
If my understanding is correct, CfL was performed twice. Once in the code that was removed, and once in the else statement of is_inter (inside transform_block).