### PR TITLE
[CFL] Perform DC Prediction Prior to CfL Pred

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -2983,10 +2983,8 @@ is_scaled( refFrame ) {
 |         if ( ( ( plane == 0 ) && PaletteSizeY ) \|\|
 |              ( ( plane != 0 ) && PaletteSizeUV ) ) {
 |             predict_palette( plane, startX, startY, x, y, txSz )
-|         } else if ( IsCFL ) {
-|             predict_chroma_from_luma( plane, startX, startY, txSz )
 |         } else {
-|             mode = ( plane == 0 ) ? YMode : UVMode
+|             mode = ( plane == 0 ) ? YMode : get_mode_from_uv(UVMode)
 |             log2W = Tx_Width_Log2[ txSz ]
 |             log2H = Tx_Height_Log2[ txSz ]
 |             predict_intra( plane, startX, startY,
@@ -3000,7 +2998,11 @@ is_scaled( refFrame ) {
 |                                        [ ( subBlockMiCol \>\> subX ) - 1 ],
 |                            mode,
 |                            log2W, log2H )
+|             if ( IsCFL ) {
+|                 predict_chroma_from_luma( plane, startX, startY, txSz )
+|             }
 |         }
+|         
 |         if (plane == 0) {
 |             MaxLumaW = startX + stepX * 4
 |             MaxLumaH = startY + stepY * 4
@@ -3024,6 +3026,17 @@ is_scaled( refFrame ) {
 | }
 {:.syntax }
 
+where get_mode_from_uv converts a **uv_mode** to an **intra_frame_y_mode** and is defined as:
+
+~~~~~ c
+get_mode_from_uv( uv_mode ) {
+    if ( uv_mode == UV_CFL_PRED){
+        return DC_PRED
+    } else {
+        return uv_mode
+    }
+}
+~~~~~
 
 #### Transform Tree Syntax
 


### PR DESCRIPTION
Using get_mode_from_uv() we convert UV_CFL_PRED to DC_PRED and call predict_intra. This will fill the block to encode in CurrFrame with Intra DC Prediction. Afterwards, we call predict_chroma_from_luma to add the AC contribution over the Intra DC Prediction.