### PR TITLE
Chroma TX size adjustement

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -3088,8 +3088,15 @@ find_tx_size( w, h ) {
 |     if ( plane == 0 )
 |         return txSz
 |     uvTx = Max_Tx_Size_Rect[ get_plane_residual_size( MiSize, plane ) ]
-|     if ( Tx_Width[ uvTx ] == 64 \|\| Tx_Height[ uvTx ] == 64 )
+|     if ( Tx_Width[ uvTx ] == 64 \|\| Tx_Height[ uvTx ] == 64 ){
+|         if (Tx_Width[ uvTx ] == 16) {
+|             return TX_16X32
+|         }
+|         if (Tx_Height[ uvTx ] == 16) {
+|             return TX_32X16
+|         }
 |         return TX_32X32
+|     }
 |     return uvTx
 | }
 {:.syntax }


### PR DESCRIPTION
The get_tx_size() function (in the spec) also includes the av1_get_max_uv_txsize function (in libaom). However, I don't see the final adjustment:
  switch (uv_tx) {
    case TX_64X64:
    case TX_64X32:
    case TX_32X64: return TX_32X32;
    case TX_64X16: return TX_32X16;
    case TX_16X64: return TX_16X32;
    default: break;
  }
This adds that support (this is not an issue for 4:2:0, but occurs in 4:4:4).