### PR TITLE
[Editorial] Clarify Max_Tx_Depth interpretation

### DIFF
--- a/03.symbols.md
+++ b/03.symbols.md
@@ -171,7 +171,7 @@ Additional constants are defined below:
 | `REF_CAT_LEVEL`                  | 640       | Bonus weight for close motion vectors
 | `MAX_REF_MV_STACK_SIZE`          | 8         | Maximum number of motion vectors in the stack
 | `MFMV_STACK_SIZE`                | 3         | Stack size for motion field motion vectors
-| `MAX_TX_DEPTH`                   | 2         | Number of contexts for tx_depth when the maximum transform size is 8x8
+| `MAX_TX_DEPTH`                   | 2         | Maximum times the transform can be split
 | `WEDGE_TYPES`                    | 16        | Number of directions for the wedge mask process
 | `FILTER_BITS`                    | 7         | Number of bits used in Wiener filter coefficients
 | `WIENER_COEFFS`                  | 3         | Number of Wiener filter coefficients to read

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -2329,8 +2329,8 @@ neg_deinterleave(diff, ref, max) {
 | }
 {:.syntax }
 
-The Max_Tx_Depth table specifies the maximum transform depth which
-can be encoded for each block size:
+The Max_Tx_Depth table specifies the maximum transform depth
+for each block size:
 
 ~~~~~ c
 Max_Tx_Depth[ BLOCK_SIZES ] = {
@@ -2343,6 +2343,13 @@ Max_Tx_Depth[ BLOCK_SIZES ] = {
 }
 ~~~~~
 
+**Note:** Max_Tx_Depth contains the number of times
+the transform must be split to reach a 4x4 transform size.
+This number can be greater than MAX_TX_DEPTH.
+However, it is impossible to encode a transform depth
+greater than MAX_TX_DEPTH because
+tx_depth can only encode values in the range 0 to 2
+{:.alert .alert-info }
 
 #### Block TX size syntax
 


### PR DESCRIPTION
This rewrites the explanation for the Max_Tx_Depth array.

No change to the normative behaviour.

BUG=aomedia:1985