### PR TITLE
Replace Tile with Frame in count_units_in_frame

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -4230,8 +4230,8 @@ is_inside_filter_region determines whether a candidate position is inside the re
 where count_units_in_frame is a function specified as:
 
 ~~~~~ c
-count_units_in_frame(unitSize, tileSize) {
-    return Max((tileSize + (unitSize >> 1)) / unitSize, 1)
+count_units_in_frame(unitSize, frameSize) {
+    return Max((frameSize + (unitSize >> 1)) / unitSize, 1)
 }
 ~~~~~
 


### PR DESCRIPTION
The variable TileSize is confusing in count_units_in_frame as it is not the tile size. This gives the false impression that Restoration Units are bound by tile boundaries and contradicts the name of the function. FrameSize seems more appropriate variable name given the name of the function.