### PR TITLE
Restrict context_update_tile_id to indicate a valid tile

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1921,6 +1921,7 @@ for each tile down the image.
 **maxTileHeightSb** specifies the maximum height (in units of superblocks) that can be used for a tile (to avoid making tiles with too much area).
 
 **context_update_tile_id** specifies which tile to use for the CDF update.
+It is a requirement of bitstream conformance that context_update_tile_id is less than TileCols * TileRows.
 
 **tile_size_bytes_minus_1** is used to compute TileSizeBytes.
 


### PR DESCRIPTION
For small image sizes the number of tiles is not always a power
of two and so it is possible for context_update_tile_id to
indicate a tile that is not present.