### PR TITLE
Correct ratio outside range is 1:4 to 4:1

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2318,7 +2318,10 @@ get_plane_residual_size( subSize, 1 ) is not equal to BLOCK_INVALID every time
 subSize is computed.
 
 **Note:** This requirement prevents the UV blocks from being too tall or too
-wide (i.e. having aspect ratios outside the range 1:2 to 2:1).
+wide (i.e. having aspect ratios outside the range 1:4 to 4:1). For example, 
+when 4:2:2 chroma subsampling is used a luma partition of size 8x32 is invalid,
+as it implies a chroma partition of size 4x32, which is results in an aspect
+ratio of 1:8.
 {:.alert .alert-info }
 
 **split_or_vert** is used to compute partition for blocks when only split or

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2320,7 +2320,7 @@ subSize is computed.
 **Note:** This requirement prevents the UV blocks from being too tall or too
 wide (i.e. having aspect ratios outside the range 1:4 to 4:1). For example, 
 when 4:2:2 chroma subsampling is used a luma partition of size 8x32 is invalid,
-as it implies a chroma partition of size 4x32, which is results in an aspect
+as it implies a chroma partition of size 4x32, which results in an aspect
 ratio of 1:8.
 {:.alert .alert-info }
 


### PR DESCRIPTION
1:4 and 4:1 are valid and are already outside the range of 1:2 to 2:1. Adds a concrete example to help explain this requirement.