### PR TITLE
Correct semantics for compound_idx

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2908,8 +2908,8 @@ wedge_interintra equal to 0 specifies that intra blending should be used.
 **comp_group_idx** equal to 0 indicates that the compound_idx syntax element should be read.
 comp_group_idx equal to 1 indicates that the compound_idx syntax element is not present.
 
-**compound_idx** equal to 1 indicates that a distance based weighted scheme should be used for blending.
-compound_idx equal to 0 indicates that the averaging scheme should be used for blending. 
+**compound_idx** equal to 0 indicates that a distance based weighted scheme should be used for blending.
+compound_idx equal to 1 indicates that the averaging scheme should be used for blending. 
 
 **compound_type** specifies how the two predictions should be blended together:
 


### PR DESCRIPTION
The explanation in the semantics for compound_idx conflict with the equation in the syntax tables.

The syntax table equation matches the reference code.

This change fixes the semantics to match.

BUG=aomedia:2116