### PR TITLE
[Editorial] Remove misleading description of entropy coded parts

### DIFF
--- a/09.parsing.process.md
+++ b/09.parsing.process.md
@@ -28,8 +28,7 @@ The value for the syntax element is given by x.
 
 #### General
 
-Aside from the uncompressed header and the partition sizes, the entire
-bitstream is entropy coded. The entropy decoder is referred to as the "Symbol
+The entropy decoder is referred to as the "Symbol
 decoder" and the functions init_symbol( sz ), exit_symbol( ), read_symbol( cdf ), and read_bool( )
 are used in this Specification to indicate the entropy decoding operation.
 


### PR DESCRIPTION
BUG=#170