### PR TITLE
[Editorial] Wiener filter optimization

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -6502,7 +6502,7 @@ The filtering is applied as follows:
     ~~~~~ c
     offset = (1 << (BitDepth + FILTER_BITS - InterRound0 - 1))
     limit = (1 << (BitDepth + 1 + FILTER_BITS - InterRound0)) - 1
-    for ( r = 0; r < h + 7; r++ ) {
+    for ( r = 0; r < h + 6; r++ ) {
         for ( c = 0; c < w; c++ ) {
             s = 0
             for ( t = 0; t < 7; t++ )


### PR DESCRIPTION
The last row fetched for Wiener filter is unused.
Therefore we can reduce the number of rows fetched by one.

BUG=aomedia:2165