### PR TITLE
Simplify syntax in uncompressed_header()

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -729,60 +729,51 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |             }
 |         }
 |     }
-|     if ( frame_type == KEY_FRAME ) {
+|     if ( frame_type == KEY_FRAME \|\| frame_type == INTRA_ONLY_FRAME ) {
 |         frame_size( )
 |         render_size( )
 |         if ( allow_screen_content_tools && UpscaledWidth == FrameWidth ) {
 |             @@allow_intrabc                               | f(1)
 |         }
 |     } else {
-|         if ( frame_type == INTRA_ONLY_FRAME ) {
+|         if ( !enable_order_hint ) {
+|           frame_refs_short_signaling = 0
+|         } else {
+|           @@frame_refs_short_signaling                    | f(1)
+|           if ( frame_refs_short_signaling ) {
+|             @@last_frame_idx                              | f(3)
+|             @@gold_frame_idx                              | f(3)
+|             set_frame_refs()
+|           }
+|         }
+|         for ( i = 0; i < REFS_PER_FRAME; i++ ) {
+|             if ( !frame_refs_short_signaling )
+|               @@ref_frame_idx[ i ]                        | f(3)
+|             if ( frame_id_numbers_present_flag ) {
+|                 n = delta_frame_id_length_minus_2 + 2
+|                 @@delta_frame_id_minus_1                  | f(n)
+|                 DeltaFrameId = delta_frame_id_minus_1 + 1
+|                 expectedFrameId[ i ] = ((current_frame_id + (1 \<\< idLen) -
+|                                         DeltaFrameId ) % (1 \<\< idLen))
+|             }
+|         }
+|         if ( frame_size_override_flag && !error_resilient_mode ) {
+|             frame_size_with_refs( )
+|         } else {
 |             frame_size( )
 |             render_size( )
-|             if ( allow_screen_content_tools && UpscaledWidth == FrameWidth ) {
-|                 @@allow_intrabc                           | f(1)
-|             }
+|         }
+|         if ( force_integer_mv ) {
+|             allow_high_precision_mv = 0
 |         } else {
-|             if ( !enable_order_hint ) {
-|               frame_refs_short_signaling = 0
-|             } else {
-|               @@frame_refs_short_signaling                | f(1)
-|               if ( frame_refs_short_signaling ) {
-|                 @@last_frame_idx                          | f(3)
-|                 @@gold_frame_idx                          | f(3)
-|                 set_frame_refs()
-|               }
-|             }
-|             for ( i = 0; i < REFS_PER_FRAME; i++ ) {
-|                 if ( !frame_refs_short_signaling )
-|                   @@ref_frame_idx[ i ]                    | f(3)
-|                 if ( frame_id_numbers_present_flag ) {
-|                     n = delta_frame_id_length_minus_2 + 2
-|                     @@delta_frame_id_minus_1               | f(n)
-|                     DeltaFrameId = delta_frame_id_minus_1 + 1
-|                     expectedFrameId[ i ] = ((current_frame_id + (1 \<\< idLen) -
-|                                             DeltaFrameId ) % (1 \<\< idLen))
-|                 }
-|             }
-|             if ( frame_size_override_flag && !error_resilient_mode ) {
-|                 frame_size_with_refs( )
-|             } else {
-|                 frame_size( )
-|                 render_size( )
-|             }
-|             if ( force_integer_mv ) {
-|                 allow_high_precision_mv = 0
-|             } else {
-|                 @@allow_high_precision_mv                 | f(1)
-|             }
-|             read_interpolation_filter( )
-|             @@is_motion_mode_switchable                   | f(1)
-|             if ( error_resilient_mode \|\|
-|                  !enable_ref_frame_mvs ) {
-|                 use_ref_frame_mvs = 0
-|             } else {
-|                 @@use_ref_frame_mvs                       | f(1)
-|             }
+|             @@allow_high_precision_mv                     | f(1)
+|         }
+|         read_interpolation_filter( )
+|         @@is_motion_mode_switchable                       | f(1)
+|         if ( error_resilient_mode \|\| !enable_ref_frame_mvs ) {
+|             use_ref_frame_mvs = 0
+|         } else {
+|             @@use_ref_frame_mvs                           | f(1)
 |         }
 |     }
 |     if ( !FrameIsIntra ) {

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -729,7 +729,7 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |             }
 |         }
 |     }
-|     if ( frame_type == KEY_FRAME \|\| frame_type == INTRA_ONLY_FRAME ) {
+|     if (  FrameIsIntra ) {
 |         frame_size( )
 |         render_size( )
 |         if ( allow_screen_content_tools && UpscaledWidth == FrameWidth ) {
@@ -775,8 +775,6 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |         } else {
 |             @@use_ref_frame_mvs                           | f(1)
 |         }
-|     }
-|     if ( !FrameIsIntra ) {
 |         for ( i = 0; i < REFS_PER_FRAME; i++ ) {
 |             refFrame = LAST_FRAME + i
 |             hint = RefOrderHint[ ref_frame_idx[ i ] ]


### PR DESCRIPTION
Combine the parsing of frame_size/render_size when frame_type is
KEY_FRAME and INTRA_ONLY_FRAME.