### PR TITLE
Split table headings in sec 6.10.19 over two lines to reduce width

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2595,24 +2595,24 @@ txfm_split equal to 0 specifies that the block should not be split any more.
 
 The transform sets determine what subset of transform types can be used, according to the following table.
 
-| Transform type    | TX_SET_DCTONLY | TX_SET_INTRA_1 | TX_SET_INTRA_2 | TX_SET_INTER_1 | TX_SET_INTER_2 | TX_SET_INTER_3 |
-|:-----------------:|:--------------:|:--------------:|:--------------:|:--------------:|:--------------:|:--------------:|
-| DCT_DCT           | X              | X              | X              | X              | X              | X              |
-| ADST_DCT          |                | X              | X              | X              | X              |                |
-| DCT_ADST          |                | X              | X              | X              | X              |                |
-| ADST_ADST         |                | X              | X              | X              | X              |                |
-| FLIPADST_DCT      |                |                |                | X              | X              |                |
-| DCT_FLIPADST      |                |                |                | X              | X              |                |
-| FLIPADST_FLIPADST |                |                |                | X              | X              |                |
-| ADST_FLIPADST     |                |                |                | X              | X              |                |
-| FLIPADST_ADST     |                |                |                | X              | X              |                |
-| IDTX              |                | X              | X              | X              | X              | X              |
-| V_DCT             |                | X              |                | X              | X              |                |
-| H_DCT             |                | X              |                | X              | X              |                |
-| V_ADST            |                |                |                | X              |                |                |
-| H_ADST            |                |                |                | X              |                |                |
-| V_FLIPADST        |                |                |                | X              |                |                |
-| H_FLIPADST        |                |                |                | X              |                |                |
+| Transform type    | TX_SET_<br/>DCTONLY | TX_SET_<br/>INTRA_1 | TX_SET_<br/>INTRA_2 | TX_SET_<br/>INTER_1 | TX_SET_<br/>INTER_2 | TX_SET_<br/>INTER_3 |
+|:-----------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
+| DCT_DCT           | X                   | X                   | X                   | X                   | X                   | X                   |
+| ADST_DCT          |                     | X                   | X                   | X                   | X                   |                     |
+| DCT_ADST          |                     | X                   | X                   | X                   | X                   |                     |
+| ADST_ADST         |                     | X                   | X                   | X                   | X                   |                     |
+| FLIPADST_DCT      |                     |                     |                     | X                   | X                   |                     |
+| DCT_FLIPADST      |                     |                     |                     | X                   | X                   |                     |
+| FLIPADST_FLIPADST |                     |                     |                     | X                   | X                   |                     |
+| ADST_FLIPADST     |                     |                     |                     | X                   | X                   |                     |
+| FLIPADST_ADST     |                     |                     |                     | X                   | X                   |                     |
+| IDTX              |                     | X                   | X                   | X                   | X                   | X                   |
+| V_DCT             |                     | X                   |                     | X                   | X                   |                     |
+| H_DCT             |                     | X                   |                     | X                   | X                   |                     |
+| V_ADST            |                     |                     |                     | X                   |                     |                     |
+| H_ADST            |                     |                     |                     | X                   |                     |                     |
+| V_FLIPADST        |                     |                     |                     | X                   |                     |                     |
+| H_FLIPADST        |                     |                     |                     | X                   |                     |                     |
 {:.table .table-sm .table-bordered }
 
 


### PR DESCRIPTION
Unable to test whether this would fix the PDF - could you test, @louquillio? Thanks, Jack

BUG:#200