### PR TITLE
Font size override for too-wide PDF tables

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2613,7 +2613,7 @@ The transform sets determine what subset of transform types can be used, accordi
 | H_ADST            |                |                |                | X              |                |                |
 | V_FLIPADST        |                |                |                | X              |                |                |
 | H_FLIPADST        |                |                |                | X              |                |                |
-{:.table .table-sm .table-bordered }
+{:.table .table-sm .table-bordered .table-xsm }
 
 
 **inter_tx_type** specifies the transform type for inter blocks.

--- a/assets/css/av1-spec-print.sass
+++ b/assets/css/av1-spec-print.sass
@@ -98,4 +98,8 @@ a
   color: #0a3f77
 code
   color: #1c561e
-
+// One-off font-size reduction for PDF tables that exceed page width
+body
+  .table-xsm
+    th, td
+      font-size: 75%


### PR DESCRIPTION
Potentially fixes #200