### PR TITLE
Allow different temporal_id values in the same temporal unit

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -726,7 +726,10 @@ the (spatial_layers_cnt_minus_1 + 1) layers, or that it they are not present whe
 
 **temporal_group_description_present_flag** indicates when set to 1 that the temporal dependency 
 information is present, or that it is not when set to 0. 
- 
+When any temporal unit in a coded video sequence contains OBU extension headers
+that have temporal_id values that are not equal to each other,
+temporal_group_description_present_flag must be equal to 0.
+
 **scalability_structure_reserved_3bits** must be set to zero and be ignored by decoders.
 
 **spatial_layer_max_width[ i ]** specifies the maximum frame width for the frames with 

--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -340,8 +340,8 @@ For each operating point, the following constraints must hold:
 A frame header and its associated tile group OBUs within a temporal unit must use the same value of 
 obu_extension_flag (i.e., either both include or both not include the optional OBU extension header).
 
-The value of temporal_id must be the same in all OBU extension headers that are contained in the same 
-temporal unit.
+All OBU extension headers that are contained in the same temporal unit and have
+the same spatial_id value must have the same temporal_id value.
 
 If a coded video sequence contains at least one enhancement layer (OBUs with spatial_id greater than 0
 or temporal_id greater than 0) 


### PR DESCRIPTION
Proposal from Google to allow smoother bitrate distribution
when using multiple spatial layers.