### PR TITLE
Large Scale Tile: Option 1: multiple tile lists, one output frame per tile list, per rendered frame

### DIFF
--- a/annex.a.levels.md
+++ b/annex.a.levels.md
@@ -259,7 +259,7 @@ and not decode anything bigger than that.
 {:.alert .alert-info }
 
 A level X.Y compliant decoder should be able to decode tile list OBUs (via the
-large scale tile decoding process) at a rate of 90 tile list OBUs per second subject to the following level-dependent constraints:
+large scale tile decoding process) at a rate of 180 tile list OBUs per second subject to the following level-dependent constraints:
 
   * UpscaledWidth * FrameHeight is less than or equal to MaxPicSize
   
@@ -267,8 +267,8 @@ large scale tile decoding process) at a rate of 90 tile list OBUs per second sub
   
   * FrameHeight is less than or equal to MaxVSize
   
-  * TileWidth * TileHeight * ( tile_count_minus_1 + 1 ) * 90 is less than or equal to ( MaxDecodeRate / 2 )
+  * TileWidth * TileHeight * ( tile_count_minus_1 + 1 ) * 180 is less than or equal to ( MaxDecodeRate / 2 )
   
-  * For each tile list OBU, BytesPerTileList * 8 * 90 is less than or equal to MaxBitrate
+  * For each tile list OBU, BytesPerTileList * 8 * 180 is less than or equal to MaxBitrate
 
 Where BytesPerTileList is defined as the sum of (coded_tile_data_size_minus_1 + 1) for each tile list entry in the tile list OBU.

--- a/annex.d.large.scale.tile.md
+++ b/annex.d.large.scale.tile.md
@@ -25,4 +25,4 @@ The other (non-anchor) frames are referred to as "Camera Frames" and each one is
 frame as a reference. Camera frames are highlighted in gray in the figure above,
 and are shown clustered into 5x5 groups to indicate which anchor fame each uses for prediction.
  
-The application is required to render a new 3-dimensional view at a rate of 90 fps. Each rendered frame may require at most two tile list OBU as defined in [section 5.12][] to be decoded, resulting in a maximum decode rate of 180 tile list OBU per second.
+The application is required to render a new 3-dimensional view at a rate of 90 fps. Each rendered frame may require at most two tile list OBU as defined in [section 5.12][] to be decoded, resulting in a maximum decode rate of 180 tile list OBU per second. Each decoded tile list OBU produces one output frame.

--- a/annex.d.large.scale.tile.md
+++ b/annex.d.large.scale.tile.md
@@ -26,4 +26,5 @@ frame as a reference. Camera frames are highlighted in gray in the figure above,
 and are shown clustered into 5x5 groups to indicate which anchor fame each uses for prediction.
  
 The application is required to render a new 3-dimensional view at a rate of 90 fps.
-Each rendered frame is created from a single set of tiles as specified by a tile_list_obu as defined in [section 5.12][].
+Each rendered frame is created from at most two sets
+of tiles as specified by a tile_list_obu as defined in [section 5.12][].

--- a/annex.d.large.scale.tile.md
+++ b/annex.d.large.scale.tile.md
@@ -25,6 +25,4 @@ The other (non-anchor) frames are referred to as "Camera Frames" and each one is
 frame as a reference. Camera frames are highlighted in gray in the figure above,
 and are shown clustered into 5x5 groups to indicate which anchor fame each uses for prediction.
  
-The application is required to render a new 3-dimensional view at a rate of 90 fps.
-Each rendered frame is created from at most two sets
-of tiles as specified by a tile_list_obu as defined in [section 5.12][].
+The application is required to render a new 3-dimensional view at a rate of 90 fps. Each rendered frame may require at most two tile list OBU as defined in [section 5.12][] to be decoded, resulting in a maximum decode rate of 180 tile list OBU per second.


### PR DESCRIPTION
A single rendered frame might require more than one tile list to be decoded.
