### PR TITLE
Large Scale Tile: Option 2: one tile list, multiple output frames per rendered frame

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -170,12 +170,12 @@ for ( y = 0; y < h; y++ ) {
 }
 ~~~~~
 
-OutputFrameY (representing the luma plane of the output frame) is outputW samples across by outputH samples down.
+Each entry in OutputFrameY (an array representing the luma plane of each output frame) is outputW samples across by outputH samples down.
 
-OutputFrameU (representing the U plane of the output frame) is
+Each entry in OutputFrameU (an array representing the U plane of each output frame) is
 ( outputW \>\> subsampling_x ) samples across by ( outputH \>\> subsampling_y ) samples down.
 
-OutputFrameV (representing the V plane of the output frame) is
+Each entry in OutputFrameV (an array representing the V plane of each output frame) is
 ( outputW \>\> subsampling_x ) samples across by ( outputH \>\> subsampling_y ) samples down.
 
 The bitdepth of each output sample is given by BitDepth.

--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -129,10 +129,13 @@ For each tile list entry in the tile list OBU, the following ordered steps are a
   
   13. RefBitDepth[ last ] is set equal to BitDepth.
   
-  14. Invoke the decode camera tile process specified in [section 7.3.2][]
-      and write the decoded tiles into one or more output frames in raster order, in the order that they occur in the tile list OBU.
+  14. Invoke the decode camera tile process specified in [section 7.3.2][] and write the decoded tiles into one or more output frames in raster order, in the order that they occur in the tile list OBU. As each output frame is completely filled with decoded tiles, the decoder should write the next decoded tile at the start of the next output buffer.
 
-The output from this process is the output frame that is built up in the final step above.
+The output from this process are the output frames that are built up in the final step above. There will be 
+1 + (tile_count_minus_1 / ((output_frame_width_in_tiles_minus_1 + 1) * (output_frame_width_in_tiles_minus_1 + 1)))
+output frames for each decoded tile list OBU.
+
+**Note:** The management of output buffers is an implementation detail.
 
 The variable outputW is defined as ( 1 + output_frame_width_in_tiles_minus_1 ) * TileWidth.
 

--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -6,7 +6,7 @@ AV1 contains two operating modes:
 
   1. General decoding (input is a sequence of OBUs, output is decoded frames)
   
-  2. Large scale tile decoding (input is a tile list OBU plus additional side information, output is a decoded frame)
+  2. Large scale tile decoding (input is a tile list OBU plus additional side information, output is one or more decoded frames)
   
 The general decoding process is specified in [section 7.2][].
 
@@ -85,7 +85,7 @@ The inputs to this process are:
  
 The output from this process is:
  
-  * an output frame containing decoded tiles in raster order.
+  * one or more output frames containing decoded tiles in raster order.
 
 **Note:** The syntax elements from the sequence header and frame header may be produced by decoding a sequence header OBU and a frame header OBU,
 but this is not a requirement of decoder conformance.
@@ -130,7 +130,7 @@ For each tile list entry in the tile list OBU, the following ordered steps are a
   13. RefBitDepth[ last ] is set equal to BitDepth.
   
   14. Invoke the decode camera tile process specified in [section 7.3.2][]
-      and write the decoded tiles into an output frame in raster order, in the order that they occur in the tile list OBU.
+      and write the decoded tiles into one or more output frames in raster order, in the order that they occur in the tile list OBU.
 
 The output from this process is the output frame that is built up in the final step above.
 
@@ -142,13 +142,17 @@ The operation of writing a decoded tile (with zero-based index given by the vari
 into the output frame in raster order is defined as follows:
 
 ~~~~~ c
-destX = TileWidth * ( tile % (output_frame_width_in_tiles_minus_1 + 1) )
-destY = TileHeight * ( tile / (output_frame_width_in_tiles_minus_1 + 1) )
+tilesPerOutputFrame = (output_frame_height_in_tiles_minus_1 + 1) *
+                      (output_frame_width_in_tiles_minus_1 + 1)
+outputFrameIdx = tile / tilesPerOutputFrame
+tileIdxInOutputFrame = tile % tilesPerOutputFrame
+destX = TileWidth * ( tileIdxInOutputFrame % (output_frame_width_in_tiles_minus_1 + 1) )
+destY = TileHeight * ( tileIdxInOutputFrame / (output_frame_width_in_tiles_minus_1 + 1) )
 w = TileWidth
 h = TileHeight
 for ( y = 0; y < h; y++ ) {
   for ( x = 0; x < w; x++ ) {
-    OutputFrameY[ y + destY ][ x + destX ] = OutY[ y ][ x ]
+    OutputFrameY[ outputFrameIdx ][ y + destY ][ x + destX ] = OutY[ y ][ x ]
   }
 }
 w = w >> subsampling_x
@@ -157,8 +161,8 @@ destX = destX >> subsampling_x
 destY = destY >> subsampling_y
 for ( y = 0; y < h; y++ ) {
   for ( x = 0; x < w; x++ ) {
-    OutputFrameU[ y + destY ][ x + destX ] = OutU[ y ][ x ]
-    OutputFrameV[ y + destY ][ x + destX ] = OutV[ y ][ x ]
+    OutputFrameU[ outputFrameIdx ][ y + destY ][ x + destX ] = OutU[ y ][ x ]
+    OutputFrameV[ outputFrameIdx ][ y + destY ][ x + destX ] = OutV[ y ][ x ]
   }
 }
 ~~~~~
@@ -173,7 +177,7 @@ OutputFrameV (representing the V plane of the output frame) is
 
 The bitdepth of each output sample is given by BitDepth.
 
-The output frame may not be fully covered with decoded tiles.
+An output frame may not be fully covered with decoded tiles.
 The decoder should not modify samples in the output frame outside of the boundaries of the decoded tiles.
 
 Decoders that support large scale tile decoding
@@ -235,9 +239,7 @@ It is a requirement of bitstream conformance that the following conditions are m
   
   * reference_select is equal to 0
   
-  * loop_filter_level[ 0 ] and loop_filter_level[ 1 ] are equal to 0
-  
-  * tile_count_minus_1 + 1 is less than or equal to (output_frame_width_in_tiles_minus_1 + 1) * (output_frame_height_in_tiles_minus_1 + 1).
+  * loop_filter_level[ 0 ] and loop_filter_level[ 1 ] are equal to 0.
 
 #### Decode camera tile process
 


### PR DESCRIPTION
This presents the option of requiring the decoder to handle writing multiple output frames per tile list, but only one tile list per rendered frame.