### PR TITLE
Update version to 1.1.0

### DIFF
--- a/00.cover-legend.md
+++ b/00.cover-legend.md
@@ -1,18 +1,22 @@
 <div id="cover-legend" class="alert alert-secondary" style="color: #000;" markdown="1">
 
-**Version 1.0.0**
+**Version 1.1.0**
 {:.no_toc .no_count style="font-size: 1.2rem"}
 
-This version 1.0.0 of the AV1 Bitstream Specification corresponds to the Git tag
-**[v1.0.0]** in the **[AOMediaCodec/av1-spec]** project. Its content has been
+This version 1.1.0 of the AV1 Bitstream Specification supercedes all previous
+versions of the AV1 Bitstream Specification, most notably version 1.0.0, which
+is now obsolete.
+
+This version 1.1.0 of the AV1 Bitstream Specification corresponds to the Git tag
+**[v1.1.0]** in the **[AOMediaCodec/av1-spec]** project. Its content has been
 validated as consistent with the reference decoder provided by
-**[libaom v1.0.0]**.
+**[libaom v1.1.0]**.
 
 To comment on this document, use the [mailing list] or the [issue tracker].
 
-[v1.0.0]: https://github.com/AOMediaCodec/av1-spec/releases/tag/v1.0.0
+[v1.1.0]: https://github.com/AOMediaCodec/av1-spec/releases/tag/v1.1.0
 [AOMediaCodec/av1-spec]: https://github.com/AOMediaCodec/av1-spec
-[libaom v1.0.0]: https://aomedia-review.googlesource.com/admin/repos/aom,tags
+[libaom v1.1.0]: https://aomedia-review.googlesource.com/admin/repos/aom,tags
 [issue tracker]: https://github.com/AOMediaCodec/av1-spec/issues
 [mailing list]: https://groups.google.com/a/aomedia.org/forum/#!forum/av1-discuss
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,8 +4,8 @@ Peter de Rivaz, Argon Design Ltd
 Jack Haughton, Argon Design Ltd
 
 **Codec Working Group Chair**  
-Adrian Grange, Google Inc
+Adrian Grange, Google LLC
 
 **Design**  
-Lou Quillio, Google Inc
+Lou Quillio, Google LLC
 


### PR DESCRIPTION
Update the specification version number to "v1.1.0" (was "v1.0.0").

Change Google Inc --> Google LLC for authors.