### PR TITLE
Remove stray leading and trailing spaces in 07 bitstream semantics

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -608,12 +608,12 @@ entity identified by the ITU-T T.35 country code and terminal provider code.
 
 #### Metadata scalability semantics
 
-**Note:** The scalability metadata OBU is intended for use by intermediate processing entities that may 
-perform selective layer elimination.  Its presence allows these entities to know the structure of the 
+**Note:** The scalability metadata OBU is intended for use by intermediate processing entities that may
+perform selective layer elimination.  Its presence allows these entities to know the structure of the
 original coded video sequence without having to decode individual frames. If the received bitstream has been modified by an intermediate processing entity, then some of the layers and/or individual frames may be absent from the bitstream.
 {:.alert .alert-info }
 
-If scalability metadata is present it should be placed between the first sequence header and the first frame header of a coded video sequence. The information present in a scalability metadata OBU applies to the entire coded video sequence in which it is contained, and only that sequence. Redundant copies of a scalability metadata OBU may occur in any temporal unit of a coded video sequence. 
+If scalability metadata is present it should be placed between the first sequence header and the first frame header of a coded video sequence. The information present in a scalability metadata OBU applies to the entire coded video sequence in which it is contained, and only that sequence. Redundant copies of a scalability metadata OBU may occur in any temporal unit of a coded video sequence.
 
 **scalability_mode_idc** indicates the picture prediction structure of the coded video sequence.
 
@@ -796,47 +796,47 @@ structure of the video sequence as early as possible.
 
 **spatial_layers_cnt_minus_1** indicates the number of spatial layers present in the coded video sequence minus one.
 
-**spatial_layer_description_present_flag** indicates when set to 1 that the 
-spatial_layer_ref_id is present for each of the (spatial_layers_cnt_minus_1 + 1) layers, or that it is 
+**spatial_layer_description_present_flag** indicates when set to 1 that the
+spatial_layer_ref_id is present for each of the (spatial_layers_cnt_minus_1 + 1) layers, or that it is
 not present when set to 0.
 
-**spatial_layer_dimensions_present_flag** indicates when set to 1 that the 
-spatial_layer_max_width and spatial_layer_max_height parameters are present for each of 
+**spatial_layer_dimensions_present_flag** indicates when set to 1 that the
+spatial_layer_max_width and spatial_layer_max_height parameters are present for each of
 the (spatial_layers_cnt_minus_1 + 1) layers, or that it they are not present when set to 0.
 
-**temporal_group_description_present_flag** indicates when set to 1 that the temporal dependency 
-information is present, or that it is not when set to 0. 
+**temporal_group_description_present_flag** indicates when set to 1 that the temporal dependency
+information is present, or that it is not when set to 0.
 When any temporal unit in a coded video sequence contains OBU extension headers
 that have temporal_id values that are not equal to each other,
 temporal_group_description_present_flag must be equal to 0.
 
 **scalability_structure_reserved_3bits** must be set to zero and be ignored by decoders.
 
-**spatial_layer_max_width[ i ]** specifies the maximum frame width for the frames with 
+**spatial_layer_max_width[ i ]** specifies the maximum frame width for the frames with
 spatial_id equal to i. This number must not be larger than max_frame_width_minus_1 + 1.
 
-**spatial_layer_max_height[ i ]** specifies the maximum frame height for the frames with 
+**spatial_layer_max_height[ i ]** specifies the maximum frame height for the frames with
 spatial_id equal to i.  This number must not be larger than max_frame_height_minus_1 + 1.
 
-**spatial_layer_ref_id[ i ]** specifies the spatial_id value of the frame within the current 
-temporal unit that the frame of layer i uses for reference. If no frame within the current temporal unit is 
+**spatial_layer_ref_id[ i ]** specifies the spatial_id value of the frame within the current
+temporal unit that the frame of layer i uses for reference. If no frame within the current temporal unit is
 used for reference the value must be equal to 255.
 
-**temporal_group_size** indicates the number of pictures in a temporal picture group. If the 
-temporal_group_size is greater than 0, then the scalability structure data allows the inter-picture 
-temporal dependency structure of the coded video sequence to be specified.  If the temporal_group_size is 
-greater than 0, then for temporal_group_size pictures in the temporal group, each picture's temporal 
+**temporal_group_size** indicates the number of pictures in a temporal picture group. If the
+temporal_group_size is greater than 0, then the scalability structure data allows the inter-picture
+temporal dependency structure of the coded video sequence to be specified.  If the temporal_group_size is
+greater than 0, then for temporal_group_size pictures in the temporal group, each picture's temporal
 layer id (temporal_id), switch up points (temporal_group_temporal_switching_up_point_flag and
-temporal_group_spatial_switching_up_point_flag), and the reference 
-picture indices (temporal_group_ref_pic_diff) are specified.  
+temporal_group_spatial_switching_up_point_flag), and the reference
+picture indices (temporal_group_ref_pic_diff) are specified.
 
 The first picture specified in a temporal group must have temporal_id equal to 0.
 
-If the parameter temporal_group_size is not present or set to 0, then either there is only one temporal 
+If the parameter temporal_group_size is not present or set to 0, then either there is only one temporal
 layer or there is no fixed inter-picture temporal dependency present in the coded video sequence.
 
-Note that for a given picture, all frames follow the same inter-picture temporal dependency structure.  
-However, the frame rate of each layer can be different from each other.  The specified dependency 
+Note that for a given picture, all frames follow the same inter-picture temporal dependency structure.
+However, the frame rate of each layer can be different from each other.  The specified dependency
 structure in the scalability structure data must be for the highest frame rate layer.
 
 **temporal_group_temporal_id[ i ]** specifies the temporal_id value for the i-th picture in the temporal group.
@@ -851,23 +851,23 @@ picture.
 
 **temporal_group_spatial_switching_up_point_flag[ i ]**] is set to 1 if spatial layers of the
 current picture in the temporal group (i.e., pictures with a spatial_id higher than zero) do not depend on
-any picture preceding the current picture in the temporal group. 
+any picture preceding the current picture in the temporal group.
 
-**temporal_group_ref_cnt[ i ]** indicates the number of reference pictures used by the i-th picture in the 
+**temporal_group_ref_cnt[ i ]** indicates the number of reference pictures used by the i-th picture in the
 temporal group.
 
-**temporal_group_ref_pic_diff[ i ][ j ]** indicates, for the i-th picture in the temporal group, the temporal 
-distance between the i-th picture and the j-th reference picture used by the i-th picture.  The temporal 
+**temporal_group_ref_pic_diff[ i ][ j ]** indicates, for the i-th picture in the temporal group, the temporal
+distance between the i-th picture and the j-th reference picture used by the i-th picture.  The temporal
 distance is measured in frames, counting only frames of identical spatial_id values.
 
-**Note:** The scalability structure description does not allow different temporal prediction 
-structures across non-temporal layers (i.e., layers with different spatial_id values).  It also 
+**Note:** The scalability structure description does not allow different temporal prediction
+structures across non-temporal layers (i.e., layers with different spatial_id values).  It also
 only allows for a single reference picture for inter-layer prediction.
 {:.alert .alert-info }
 
-The following sections contain the value of these syntax elements for certain predefined modes. 
-Prediction structures having scalability_mode_idc values in the range 21 to 28, inclusive, cannot 
-be described using temporal group description syntax and are not described in the sections that follow.   
+The following sections contain the value of these syntax elements for certain predefined modes.
+Prediction structures having scalability_mode_idc values in the range 21 to 28, inclusive, cannot
+be described using temporal group description syntax and are not described in the sections that follow.
 
 
 ##### L1T2 (Informative)
@@ -875,7 +875,7 @@ be described using temporal group description syntax and are not described in th
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 0
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
 | 0 | temporal_group_temporal_id[0] | 0
@@ -895,7 +895,7 @@ be described using temporal group description syntax and are not described in th
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 0
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
 | 0 | temporal_group_temporal_id[0] | 0
@@ -926,7 +926,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 0
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
 | 0 | temporal_group_temporal_id[0] | 0
@@ -943,7 +943,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 0
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
 | 0 | temporal_group_temporal_id[0] | 0
@@ -965,7 +965,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 0
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
 | 0 | temporal_group_temporal_id[0] | 0
@@ -996,7 +996,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 255
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1013,7 +1013,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 255
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1035,7 +1035,7 @@ be described using temporal group description syntax and are not described in th
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 255
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1068,7 +1068,7 @@ be described using temporal group description syntax and are not described in th
 | 1 |  spatial_layer_ref_id[1] | 0
 | 2 |  spatial_layer_ref_id[1] | 1
 
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1086,7 +1086,7 @@ be described using temporal group description syntax and are not described in th
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 0
 | 2 |  spatial_layer_ref_id[1] | 1
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1109,7 +1109,7 @@ be described using temporal group description syntax and are not described in th
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 0
 | 2 |  spatial_layer_ref_id[1] | 1
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1142,7 +1142,7 @@ be described using temporal group description syntax and are not described in th
 | 1 |  spatial_layer_ref_id[1] | 255
 | 2 |  spatial_layer_ref_id[1] | 255
 
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1160,7 +1160,7 @@ be described using temporal group description syntax and are not described in th
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 255
 | 2 |  spatial_layer_ref_id[1] | 255
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1183,7 +1183,7 @@ be described using temporal group description syntax and are not described in th
 | 0 | spatial_layer_ref_id[0] | 255
 | 1 |  spatial_layer_ref_id[1] | 255
 | 2 |  spatial_layer_ref_id[1] | 255
-|  |  | 
+|  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
 | 0 | temporal_group_temporal_id[0] | 0
@@ -1239,7 +1239,7 @@ if ( equal_picture_interval ) {
   ticksPerPicture = 1
 }
 ss = ( ( hours_value * 60 + minutes_value) * 60 + seconds_value )
-clockTimestamp = ss * time_scale + n_frames * ticksPerPicture + time_offset_value 
+clockTimestamp = ss * time_scale + n_frames * ticksPerPicture + time_offset_value
 ~~~~~
 
 clockTimestamp is in units of clock ticks of a clock with clock frequency equal to time_scale Hz, relative to
@@ -1262,7 +1262,7 @@ for the previous set of clock timestamp syntax elements in output order.
 counting method specified by counting_type.
 
 **n_frames** is used to compute clockTimestamp. When
-timing_info_present_flag is equal to 1, n_frames shall be less than maxFps, where 
+timing_info_present_flag is equal to 1, n_frames shall be less than maxFps, where
 maxFps is specified by maxFps = ceil( time_scale / ( 2 * num_units_in_display_tick ) ).
 
 **seconds_flag** equal to 1 specifies that seconds_value and minutes_flag are present
@@ -1397,13 +1397,13 @@ If frame_type is not equal to KEY_FRAME or show_frame is equal to 0, it is a req
 that all of the following conditions are true:
 
   * current_frame_id is not equal to PrevFrameID,
-  
+
   * DiffFrameID is less than 1 \<\< ( idLen - 1 )
-  
+
 where DiffFrameID is specified as follows:
 
   * If current_frame_id is greater than PrevFrameID, DiffFrameID is equal to current_frame_id - PrevFrameID.
-  
+
   * Otherwise, DiffFrameID is equal to ( 1 \<\< idLen ) + current_frame_id - PrevFrameID.
 
 **frame_size_override_flag** equal to 0 specifies that the frame size is equal to the size in the sequence header.
@@ -1515,16 +1515,18 @@ order of pictures.
 
 **RefFrameId[ i ]** specifies the frame id for each reference frame.
 
-**expectedFrameId[ i ]** specifies the frame id for each frame used for reference.
-It is a requirement of bitstream conformance that whenever expectedFrameId[ i ] is calculated, the value matches
-RefFrameId[ ref_frame_idx[ i ] ] (this contains the value of current_frame_id at the time that the frame indexed by
-ref_frame_idx was stored).
+**expectedFrameId[ i ]** specifies the frame id for each frame used for
+reference. It is a requirement of bitstream conformance that whenever
+expectedFrameId[ i ] is calculated, the value matches
+RefFrameId[ ref_frame_idx[ i ] ]
+(this contains the value of current_frame_id at the time that the frame indexed
+by ref_frame_idx was stored).
 
 **allow_high_precision_mv** equal to 0 specifies that motion vectors are
 specified to quarter pel precision; allow_high_precision_mv equal to 1
 specifies that motion vectors are specified to eighth pel precision.
 
-**is_motion_mode_switchable** equal to 0 specifies that only the SIMPLE 
+**is_motion_mode_switchable** equal to 0 specifies that only the SIMPLE
 motion mode will be used.
 
 **use_ref_frame_mvs** equal to 1 specifies that motion vector information
@@ -1569,9 +1571,9 @@ is invoked the following takes place:
 
   * PrevSegmentIds[ row ][ col ] is set equal to 0 for row = 0..MiRows-1 and
     col = 0..MiCols-1.
-    
+
   * GmType[ ref ] is set equal to IDENTITY for ref = LAST_FRAME..ALTREF_FRAME.
-  
+
   * PrevGmParams[ ref ][ i ] is set equal to ( ( i % 3 == 2 ) ? 1 \<\< WARPEDMODEL_PREC_BITS : 0 )
     for ref = LAST_FRAME..ALTREF_FRAME, for i = 0..5.
 
@@ -1602,11 +1604,11 @@ this function is invoked, the following steps apply:
   * YModeCdf is set to a copy of Default_Y_Mode_Cdf
 
   * UVModeCflNotAllowedCdf is set to a copy of Default_Uv_Mode_Cfl_Not_Allowed_Cdf
-  
+
   * UVModeCflAllowedCdf is set to a copy of Default_Uv_Mode_Cfl_Allowed_Cdf
-  
+
   * AngleDeltaCdf is set to a copy of Default_Angle_Delta_Cdf
-  
+
   * IntrabcCdf is set to a copy of Default_Intrabc_Cdf
 
   * PartitionW8Cdf is set to a copy of Default_Partition_W8_Cdf
@@ -1628,9 +1630,9 @@ this function is invoked, the following steps apply:
   * Tx16x16Cdf is set to a copy of Default_Tx_16x16_Cdf
 
   * Tx32x32Cdf is set to a copy of Default_Tx_32x32_Cdf
-  
+
   * Tx64x64Cdf is set to a copy of Default_Tx_64x64_Cdf
-  
+
   * TxfmSplitCdf is set to a copy of Default_Txfm_Split_Cdf
 
   * FilterIntraModeCdf is set to a copy of Default_Filter_Intra_Mode_Cdf
@@ -1656,7 +1658,7 @@ this function is invoked, the following steps apply:
   * CompModeCdf is set to a copy of Default_Comp_Mode_Cdf
 
   * SkipModeCdf is set to a copy of Default_Skip_Mode_Cdf
-  
+
   * SkipCdf is set to a copy of Default_Skip_Cdf
 
   * CompRefCdf is set to a copy of Default_Comp_Ref_Cdf
@@ -1678,7 +1680,7 @@ this function is invoked, the following steps apply:
   * MvClass0HpCdf[ i ][ comp ] is set to a copy of Default_Mv_Class0_Hp_Cdf for i = 0..MV_CONTEXTS-1 and comp = 0..1
 
   * MvSignCdf[ i ][ comp ] is set to a copy of Default_Mv_Sign_Cdf for i = 0..MV_CONTEXTS-1 and comp = 0..1
-  
+
   * MvBitCdf[ i ][ comp ] is set to a copy of Default_Mv_Bit_Cdf for i = 0..MV_CONTEXTS-1 and comp = 0..1
 
   * MvHpCdf[ i ][ comp ] is set to a copy of Default_Mv_Hp_Cdf for i = 0..MV_CONTEXTS-1 and comp = 0..1
@@ -1736,7 +1738,7 @@ this function is invoked, the following steps apply:
   * DeltaQCdf is set to a copy of Default_Delta_Q_Cdf
 
   * DeltaLFCdf is set to a copy of Default_Delta_Lf_Cdf
-  
+
   * DeltaLFMultiCdf[ i ] is set to a copy of Default_Delta_Lf_Cdf for i = 0..FRAME_LF_COUNT-1
 
   * IntraTxTypeSet1Cdf is set to a copy of Default_Intra_Tx_Type_Set1_Cdf
@@ -1762,65 +1764,65 @@ this function is invoked, the following steps apply:
   * WedgeInterIntraCdf is set to a copy of Default_Wedge_Inter_Intra_Cdf
 
   * CompGroupIdxCdf is set to a copy of Default_Comp_Group_Idx_Cdf
-  
+
   * CompoundIdxCdf is set to a copy of Default_Compound_Idx_Cdf
-  
+
   * CompoundTypeCdf is set to a copy of Default_Compound_Type_Cdf
 
   * InterIntraModeCdf is set to a copy of Default_Inter_Intra_Mode_Cdf
-  
+
   * WedgeIndexCdf is set to a copy of Default_Wedge_Index_Cdf
 
   * CflAlphaCdf is set to a copy of Default_Cfl_Alpha_Cdf
-  
+
   * UseWienerCdf is set to a copy of Default_Use_Wiener_Cdf
-  
+
   * UseSgrprojCdf is set to a copy of Default_Use_Sgrproj_Cdf
-  
+
   * RestorationTypeCdf is set to a copy of Default_Restoration_Type_Cdf
-    
+
 **init_coeff_cdfs( )** is a function call that indicates that the CDF tables
 used in the coeff( ) syntax structure should be initialised. When this function
 is invoked, the following steps apply:
 
   * The variable idx is derived as follows:
-  
+
     * If base_q_idx is less than or equal to 20, idx is set equal to 0.
-    
+
     * Otherwise, if base_q_idx is less than or equal to 60, idx is set equal to 1.
-    
+
     * Otherwise, if base_q_idx is less than or equal to 120, idx is set equal to 2.
-    
+
     * Otherwise, idx is set equal to 3.
-    
+
   * The cumulative distribution function arrays are reset to default values as follows:
-    
+
     * TxbSkipCdf is set to a copy of Default_Txb_Skip_Cdf[ idx ].
-    
+
     * EobPt16Cdf is set to a copy of Default_Eob_Pt_16_Cdf[ idx ].
-    
+
     * EobPt32Cdf is set to a copy of Default_Eob_Pt_32_Cdf[ idx ].
-    
+
     * EobPt64Cdf is set to a copy of Default_Eob_Pt_64_Cdf[ idx ].
-    
+
     * EobPt128Cdf is set to a copy of Default_Eob_Pt_128_Cdf[ idx ].
-    
+
     * EobPt256Cdf is set to a copy of Default_Eob_Pt_256_Cdf[ idx ].
-    
+
     * EobPt512Cdf is set to a copy of Default_Eob_Pt_512_Cdf[ idx ].
-    
+
     * EobPt1024Cdf is set to a copy of Default_Eob_Pt_1024_Cdf[ idx ].
-    
+
     * EobExtraCdf is set to a copy of Default_Eob_Extra_Cdf[ idx ].
-    
+
     * DcSignCdf is set to a copy of Default_Dc_Sign_Cdf[ idx ].
-    
+
     * CoeffBaseEobCdf is set to a copy of Default_Coeff_Base_Eob_Cdf[ idx ].
-    
+
     * CoeffBaseCdf is set to a copy of Default_Coeff_Base_Cdf[ idx ].
-    
+
     * CoeffBrCdf is set to a copy of Default_Coeff_Br_Cdf[ idx ].
-    
+
 **load_cdfs( ctx )** is a function call that indicates that the CDF tables are
 loaded from frame context number ctx in the range 0 to (NUM_REF_FRAMES - 1).
 When this function is invoked, a copy of each CDF array mentioned in the
@@ -1834,11 +1836,11 @@ previous frame may be loaded for use in decoding the current frame.
 When this function is invoked the following ordered steps apply:
 
   1. The variable prevFrame is set equal to ref_frame_idx[ primary_ref_frame ].
-  
+
   2. PrevGmParams is set equal to SavedGmParams[ prevFrame ].
-  
+
   3. The function load_loop_filter_params( prevFrame ) specified in [section 7.21][] is invoked.
-  
+
   4. The function load_segmentation_params( prevFrame ) specified in [section 7.21][] is invoked.
 
 **load_previous_segment_ids( )** is a function call that indicates that a segment map from a
@@ -1846,11 +1848,11 @@ previous frame may be loaded for use in decoding the current frame.
 When this function is invoked the segment map contained in PrevSegmentIds is set as follows:
 
   1. The variable prevFrame is set equal to ref_frame_idx[ primary_ref_frame ].
-  
+
   2. If segmentation_enabled is equal to 1, RefMiCols[ prevFrame ] is equal to MiCols, and
      RefMiRows[ prevFrame ] is equal to MiRows, PrevSegmentIds[ row ][ col ] is set equal to
-     SavedSegmentIds[ prevFrame ][ row ][ col ] for row = 0..MiRows-1, for col = 0..MiCols-1. 
-     
+     SavedSegmentIds[ prevFrame ][ row ][ col ] for row = 0..MiRows-1, for col = 0..MiCols-1.
+
      Otherwise, PrevSegmentIds[ row ][ col ] is set equal to 0 for row = 0..MiRows-1, for col = 0..MiCols-1.
 
 #### Reference frame marking semantics
@@ -2441,8 +2443,9 @@ the last tile group in each frame is equal to NumTiles - 1.
 received in order for the purposes of specifying the decode process.
 {:.alert .alert-info }
 
-**frame_end_update_cdf** is a function call that indicates that the frame CDF arrays are set equal to the 
-saved CDFs. This process is described in [section 7.7][].
+**frame_end_update_cdf** is a function call that indicates that the frame CDF
+arrays are set equal to the  saved CDFs. This process is described in
+[section 7.7][].
 
 **tile_size_minus_1** is used to compute tileSize.
 
@@ -2553,7 +2556,7 @@ get_plane_residual_size( subSize, 1 ) is not equal to BLOCK_INVALID every time
 subSize is computed.
 
 **Note:** This requirement prevents the UV blocks from being too tall or too
-wide (i.e. having aspect ratios outside the range 1:4 to 4:1). For example, 
+wide (i.e. having aspect ratios outside the range 1:4 to 4:1). For example,
 when 4:2:2 chroma subsampling is used a luma partition of size 8x32 is invalid,
 as it implies a chroma partition of size 4x32, which results in an aspect
 ratio of 1:8.
@@ -2645,8 +2648,9 @@ with an additional mode UV_CFL_PRED.
 | 13                  | UV_CFL_PRED
 {:.table .table-sm .table-bordered }
 
-**Note:** Due to the way the uv_mode syntax element is read, uv_mode can only be read as UV_CFL_PRED when 
-Max( Block_Width[ MiSize ], Block_Height[ MiSize ] ) <\= 32.
+**Note:** Due to the way the uv_mode syntax element is read, uv_mode can only be
+read as UV_CFL_PRED when Max( Block_Width[ MiSize ], Block_Height[
+MiSize ] ) <\= 32.
 {:.alert .alert-info }
 
 #### Intra segment ID semantics
@@ -2873,8 +2877,9 @@ prediction using values with the same interpretation as for intra_frame_y_mode.
 values with the same interpretation as in the semantics for intra_frame_y_mode,
 with an additional mode UV_CFL_PRED.
 
-**Note:** Due to the way the uv_mode syntax element is read, uv_mode can only be read as UV_CFL_PRED when 
-Max( Block_Width[ MiSize ], Block_Height[ MiSize ] ) <\= 32.
+**Note:** Due to the way the uv_mode syntax element is read, uv_mode can only be
+read as UV_CFL_PRED when Max( Block_Width[ MiSize ], Block_Height[
+MiSize ] ) <\= 32.
 {:.alert .alert-info }
 
 
@@ -2967,9 +2972,9 @@ reference frame to generate motion compensated prediction.
 There are two reference frame groups:
 
   * Group 1: LAST_FRAME, LAST2_FRAME, LAST3_FRAME, and GOLDEN_FRAME.
-  
+
   * Group 2: BWDREF_FRAME, ALTREF2_FRAME, and ALTREF_FRAME.
-  
+
 **Note:** Encoders are free to assign these references to any of the reference frames
 (via the ref_frame_idx array).
 For example, there is no requirement of bitstream conformance that LAST_FRAME
@@ -3147,7 +3152,7 @@ wedge_interintra equal to 0 specifies that intra blending should be used.
 comp_group_idx equal to 1 indicates that the compound_idx syntax element is not present.
 
 **compound_idx** equal to 0 indicates that a distance based weighted scheme should be used for blending.
-compound_idx equal to 1 indicates that the averaging scheme should be used for blending. 
+compound_idx equal to 1 indicates that the averaging scheme should be used for blending.
 
 **compound_type** specifies how the two predictions should be blended together:
 
@@ -3561,7 +3566,7 @@ The process for creating the AnchorFrames array is outside of the scope of this 
 
 It is a requirement of bitstream conformance that anchor_frame_idx is less than or equal to 127.
 
-**anchor_tile_row** is the row coordinate of the tile in the frame that it belongs, in tile units. 
+**anchor_tile_row** is the row coordinate of the tile in the frame that it belongs, in tile units.
 
 It is a requirement of bitstream conformance that anchor_tile_row is less than TileRows.
 


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.