### PR TITLE
Remove stray leading and trailing spaces in 08 decoding process

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -5,9 +5,9 @@
 AV1 contains two operating modes:
 
   1. General decoding (input is a sequence of OBUs, output is decoded frames)
-  
+
   2. Large scale tile decoding (input is a tile list OBU plus additional side information, output is a decoded frame)
-  
+
 The general decoding process is specified in [section 7.2][].
 
 The large scale tile decoding process is specified in [section 7.3][].
@@ -30,10 +30,10 @@ When film_grain_params_present is equal to 1, a conformant decoder shall satisfy
   frames produced by the process specified in [section 7.18.2][].
   In addition to that, a conformant decoder shall produce output frames that are in the same order and do not have perceptually
   significant differences with the frames produced by the reference film grain synthesis process specified in [section 7.18.3][]
-  when applied to the input frames of the film grain synthesis process with the film grain parameters signaled for these frames. 
-  The decoder may also include optional processing steps which are applied to the intermediate frames produced by the 
-  process specified in [section 7.18.2][] and before the film grain synthesis process, resulting in the input frames of 
-  the film grain synthesis process. Such optional processing steps are 
+  when applied to the input frames of the film grain synthesis process with the film grain parameters signaled for these frames.
+  The decoder may also include optional processing steps which are applied to the intermediate frames produced by the
+  process specified in [section 7.18.2][] and before the film grain synthesis process, resulting in the input frames of
+  the film grain synthesis process. Such optional processing steps are
   beyond the scope of this specification. Otherwise, the intermediate frames are the input frames of the film grain synthesis process.
   The definition of "perceptually significant differences" is beyond the scope of this specification and may be specified,
   for example, by a service provider as part of their accreditation program.
@@ -42,13 +42,13 @@ When film_grain_params_present is equal to 1, a conformant decoder shall satisfy
   as a function of intensity according to the signaled parameters, same maximum AR lag, and similar
   modeling of correlation between luma and chroma and smoothing of transitions between blocks of grain when applicable.
 
-**Note:** To ensure conformance, decoder manufacturers are advised to implement the film grain synthesis 
+**Note:** To ensure conformance, decoder manufacturers are advised to implement the film grain synthesis
 process as specified in [section 7.18.3][].
-One reason to choose the second conformance option is implementation of optional processing steps 
+One reason to choose the second conformance option is implementation of optional processing steps
 between the output of [section 7.18.2][] and the film grain synthesis process, in which case there could be minor differences in the output with the reference film grain synthesis process of [section 7.18.3][]. Examples of these optional processing steps are algorithms improving output picture quality, such as de-banding filtering and coding artefacts removal.
 {:.alert .alert-info }
 
-**Note:** 
+**Note:**
 Some applications, such as transcoding from AV1 to AV1, may use intermediate output frames of [section 7.18.2][] for transcoding. In such cases, the original film grain synthesis information may be adapted and inserted in the transcoded bitstream.
 {:.alert .alert-info }
 
@@ -73,25 +73,25 @@ but this is not a requirement for decoder conformance.
 {:.alert .alert-info }
 
 The inputs to this process are:
- 
+
   * contents of all syntax elements and variables produced when parsing a sequence header OBU,
-  
+
   * contents of all syntax elements and variables produced when parsing a frame header OBU
   (including CDF tables optionally loaded from a reference frame),
 
   * an array AnchorFrames containing up to 128 frames,
-  
+
   * a tile list OBU.
- 
+
 The output from this process is:
- 
+
   * an output frame containing decoded tiles in raster order.
 
 **Note:** The syntax elements from the sequence header and frame header may be produced by decoding a sequence header OBU and a frame header OBU,
 but this is not a requirement of decoder conformance.
 The AnchorFrames may be produced by decoding an AV1 bitstream, but this is not a requirement of bitstream conformance.
 {:.alert .alert-info }
- 
+
 The following figure shows the arrangement of data required to decode a single tile list OBU.
 Those data shown on a green background are normatively defined in this specification.
 Data items shown on a yellow background are defined by a process or processes beyond the scope of this specification.
@@ -104,31 +104,31 @@ Data items shown on a yellow background are defined by a process or processes be
 For each tile list entry in the tile list OBU, the following ordered steps are applied:
 
   1. Parse the syntax elements within the tile_list_entry
-  
+
   2. Set the bitstream position indicator to point to the the start of the coded_tile_data syntax element
-  
+
   3. Set the variable last equal to ref_frame_idx[ 0 ]
-  
+
   4. Set FrameStore[ last ] equal to AnchorFrames[ anchor_frame_idx ]
-  
+
   5. RefValid[ last ] is set equal to 1.
-  
+
   6. RefUpscaledWidth[ last ] is set equal to UpscaledWidth.
-  
+
   7. RefFrameWidth[ last ] is set equal to FrameWidth.
-  
+
   8. RefFrameHeight[ last ] is set equal to FrameHeight.
-  
+
   9. RefMiCols[ last ] is set equal to MiCols.
-  
+
   10. RefMiRows[ last ] is set equal to MiRows.
-  
+
   11. RefSubsamplingX[ last ] is set equal to subsampling_x.
-  
+
   12. RefSubsamplingY[ last ] is set equal to subsampling_y.
-  
+
   13. RefBitDepth[ last ] is set equal to BitDepth.
-  
+
   14. Invoke the decode camera tile process specified in [section 7.3.2][]
       and write the decoded tiles into an output frame in raster order, in the order that they occur in the tile list OBU.
 
@@ -182,61 +182,61 @@ shall produce output frames that are identical in all respects as those produced
 It is a requirement of bitstream conformance that the following conditions are met:
 
   * enable_superres is equal to 0
-  
+
   * enable_order_hint is equal to 0
-  
+
   * still_picture is equal to 0
-  
+
   * film_grain_params_present is equal to 0
-  
+
   * timing_info_present_flag is equal to 0
-  
+
   * decoder_model_info_present_flag is equal to 0
-  
+
   * initial_display_delay_present_flag is equal to 0
-  
+
   * enable_restoration is equal to 0
-  
+
   * enable_cdef is equal to 0
-  
+
   * mono_chrome is equal to 0
-  
+
   * TileHeight is equal to (use_128x128_superblock ? 128 : 64) for all tiles (i.e. the tile is exactly one superblock high)
-  
+
   * TileWidth is identical for all tiles and is an integer multiple of TileHeight (i.e. the tile is an integer number of superblocks wide)
-  
+
   * FrameWidth is equal to MiCols * MI_SIZE
-  
+
   * FrameHeight is equal to MiRows * MI_SIZE
-  
+
   * show_existing_frame is equal to 0
-  
+
   * frame_type is equal to INTER_FRAME
-  
+
   * show_frame is equal to 1
-  
+
   * error_resilient_mode is equal to 0
-  
+
   * disable_cdf_update is equal to 1
-  
+
   * disable_frame_end_update_cdf is equal to 1
-  
+
   * delta_lf_present is equal to 0
-  
+
   * delta_q_present is equal to 0
-  
+
   * frame_size_override_flag is equal to 0
-  
+
   * refresh_frame_flags is equal to 0
-  
+
   * use_ref_frame_mvs is equal to 0
-  
+
   * segmentation_temporal_update is equal to 0
-  
+
   * reference_select is equal to 0
-  
+
   * loop_filter_level[ 0 ] and loop_filter_level[ 1 ] are equal to 0
-  
+
   * tile_count_minus_1 + 1 is less than or equal to (output_frame_width_in_tiles_minus_1 + 1) * (output_frame_height_in_tiles_minus_1 + 1).
 
 #### Decode camera tile process
@@ -249,7 +249,7 @@ The output of this process are arrays OutY, OutU, OutV containing the decoded sa
 deblock, cdef, superres, loop restoration and reference frame update.
 Implementations may choose to implement this process by using the general decode process with these tools disabled.
 {:.alert .alert-info }
- 
+
 The process is specified as:
 
 ~~~~~ c
@@ -288,8 +288,8 @@ yC0 = ( MiRowStart * MI_SIZE ) >> subY
 It is a requirement of bitstream conformance that the following conditions are met whenever the parsing process returns from the read_ref_frames syntax:
 
   * RefFrame[ 0 ] = LAST_FRAME
-  
-  * RefFrame[ 1 ] = NONE 
+
+  * RefFrame[ 1 ] = NONE
 
 **Note:** It is allowed to use intra blocks, they are not forbidden by this constraint because intra blocks do not invoke the read_ref_frames syntax.
 {:.alert .alert-info }
@@ -313,21 +313,21 @@ At this stage, all the tile level decode has been done, and this process perform
 If show_existing_frame is equal to 0, the process first performs any post processing filtering by the following ordered steps:
 
   1. If loop_filter_level[ 0 ] is not equal to 0 or loop_filter_level[ 1 ] is not equal to 0, the loop
-     filter process specified in [section 7.14][] is invoked (this process modifies the contents of CurrFrame). 
-     
+     filter process specified in [section 7.14][] is invoked (this process modifies the contents of CurrFrame).
+
   2. The CDEF process specified in [section 7.15][] is invoked (this process takes CurrFrame and produces CdefFrame).
-  
+
   3. The upscaling process specified in [section 7.16][] is invoked with CdefFrame as input and the output is assigned to UpscaledCdefFrame.
-  
+
   4. The upscaling process specified in [section 7.16][] is invoked with CurrFrame as input and the output is assigned to UpscaledCurrFrame.
-  
+
   5. The loop restoration process specified in [section 7.17][] is invoked (this process takes UpscaledCurrFrame and UpscaledCdefFrame and produces LrFrame).
-  
+
   6. The motion field motion vector storage process specified in [section 7.19][] is invoked.
-  
+
   7. If segmentation_enabled is equal to 1 and segmentation_update_map is equal to 0,
      SegmentIds[ row ][ col ] is set equal to
-     PrevSegmentIds[ row ][ col ] for row = 0..MiRows-1, for col = 0..MiCols-1. 
+     PrevSegmentIds[ row ][ col ] for row = 0..MiRows-1, for col = 0..MiCols-1.
 
 Otherwise (show_existing_frame is equal to 1), if frame_type is equal to KEY_FRAME, the reference frame loading process as specified in [section 7.21][]
 is invoked (this process loads frame state from the reference frames into the current frame state variables).
@@ -336,10 +336,10 @@ The following ordered steps now apply:
 
   1. The reference frame update process as specified in [section 7.20][] is
      invoked (this process saves the current frame state into the reference frames).
-     
+
   2. If show_frame is equal to 1 or show_existing_frame is equal to 1, the output process as specified in [section 7.18][] is invoked (this will output the
      current frame or a saved frame).
-    
+
 **Note:** Although it is specified that all samples in CurrFrame are upscaled, at most 2 lines above and below each stripe
 (defined by StripeStartY and StripeEndY) will end up being read.
 Implementations may wish to avoid upscaling the unused lines.
@@ -349,9 +349,9 @@ Implementations may wish to avoid upscaling the unused lines.
 
 A bitstream conforming to this specification consists of one or more coded video sequences.
 
-A coded video sequence consists of one or more temporal units.  A temporal unit consists of a series of 
-OBUs starting from a temporal delimiter, optional sequence headers, optional metadata OBUs, a 
-sequence of one or more frame headers, each followed by zero or more tile group OBUs as well as 
+A coded video sequence consists of one or more temporal units.  A temporal unit consists of a series of
+OBUs starting from a temporal delimiter, optional sequence headers, optional metadata OBUs, a
+sequence of one or more frame headers, each followed by zero or more tile group OBUs as well as
 optional padding OBUs.
 
 A new coded video sequence is defined to start at each temporal unit which satisfies both of the following conditions:
@@ -365,32 +365,32 @@ If scalability is not being used (OperatingPointIdc equal to 0), then all frames
 The following constraints must hold:
 
   * The first frame header must have frame_type equal to KEY_FRAME and show_frame equal to 1.
-  
+
   * Each temporal unit must have exactly one shown frame.
 
 If scalability is being used (OperatingPointIdc not equal to 0), then only a subset of frames are part of the operating point.
 For each operating point, the following constraints must hold:
 
   * The first frame header that will be decoded must have frame_type equal to KEY_FRAME and show_frame equal to 1.
-  
+
   * Every layer that has a coded frame in a temporal unit must have exactly one shown frame
   that is the last frame of that layer in the temporal unit.
 
 **Note:** A shown frame is either a frame with show_frame equal to 1, or with show_existing_frame equal to 1.
 {:.alert .alert-info }
 
-A frame header and its associated tile group OBUs within a temporal unit must use the same value of 
+A frame header and its associated tile group OBUs within a temporal unit must use the same value of
 obu_extension_flag (i.e., either both include or both not include the optional OBU extension header).
 
 All OBU extension headers that are contained in the same temporal unit and have
 the same spatial_id value must have the same temporal_id value.
 
 If a coded video sequence contains at least one enhancement layer (OBUs with spatial_id greater than 0
-or temporal_id greater than 0) 
-then all frame headers and tile group OBUs associated with base (spatial_id equals 0 and temporal_id equals 0) and 
-enhancement layer (spatial_id greater than 0 or temporal_id greater than 0) data must include the OBU extension header. 
+or temporal_id greater than 0)
+then all frame headers and tile group OBUs associated with base (spatial_id equals 0 and temporal_id equals 0) and
+enhancement layer (spatial_id greater than 0 or temporal_id greater than 0) data must include the OBU extension header.
 
-OBUs with spatial level IDs (spatial_id) greater than 0 must appear within a temporal unit in 
+OBUs with spatial level IDs (spatial_id) greater than 0 must appear within a temporal unit in
 increasing order of the spatial level ID values.
 
 The first temporal unit of a coded video sequence must contain one or more sequence header OBUs before the first frame header OBU.
@@ -410,9 +410,9 @@ the parameters must be contained in a temporal unit with temporal_id equal to ze
 If a temporal unit contains one or more sequence header OBUs,
 the first appearance of the sequence header OBU must be before the first frame header OBU.
 
-One or more metadata and padding OBUs may appear in any order within an OBU sequence (unless 
-constrained by semantics provided elsewhere in this specification).  Specific metadata types may be 
-required or recommended to be placed in specific locations, as identified in their corresponding 
+One or more metadata and padding OBUs may appear in any order within an OBU sequence (unless
+constrained by semantics provided elsewhere in this specification).  Specific metadata types may be
+required or recommended to be placed in specific locations, as identified in their corresponding
 definitions.
 
 OBU types that are not defined in this specification can be ignored by a decoder.
@@ -445,19 +445,19 @@ The consequences for decoders are specified in [section 7.6.5][].
 This section defines the following terms:
 
   * key frame random access point,
-  
+
   * delayed random access point,
-  
+
   * key frame dependent recovery point.
-  
+
 A key frame random access point is defined as being a frame:
 
   * with frame_type equal to KEY_FRAME
 
-  * with show_frame equal to 1 
+  * with show_frame equal to 1
 
   * that is contained in a temporal unit that also contains a sequence header OBU
-  
+
 A delayed random access point is defined as being a frame:
 
   * with frame_type equal to KEY_FRAME
@@ -465,13 +465,13 @@ A delayed random access point is defined as being a frame:
   * with show_frame equal to 0
 
   * that is contained in a temporal unit that also contains a sequence header OBU
-  
+
 A key frame dependent recovery point is defined as being a frame:
 
   * with show_existing_frame equal to 1
 
   * with frame_to_show_map_idx specifying a frame to output that was a delayed random access point
-  
+
 #### Conformance requirements
 
 Informally, the requirement for decoder conformance is that decoding can start at any key frame random access point or delayed random access point.  The rest of this section makes this requirement more precise.
@@ -481,19 +481,19 @@ Starting at a key frame random access point is trivial, because if the earlier t
 Starting at a delayed random access point is harder to define because:
 
   * if all temporal units before the key frame dependent recovery point are dropped, it is impossible to decode (because the relevant delayed random access point has been dropped)
-  
+
   * if all temporal units before the delayed random access point are dropped, it is unclear what should happen for frames between the delayed random access point and the key-frame dependent recovery point (some applications may wish these to be dropped, while others may wish them to be displayed)
-  
+
   * in either case, the remaining temporal units do not constitute a valid standalone bitstream (because it does not start with a shown key frame)
 
 To support the different modes of operation, a conformant decoder is required to be able to decode bitstreams consisting of:
 
   * a temporal unit containing a delayed random access point
-  
+
   * immediately followed by a temporal unit containing the associated key frame dependent recovery point
-  
+
   * followed by optional additional temporal units
-  
+
 This moves the responsibility for dropping the intermediate temporal units
 (between the delayed random access point and the key frame dependent recovery point)
 out of the normatively defined decoding process into application specific behavior.
@@ -521,7 +521,7 @@ The conformance requirement means that conformant decoders must be able to start
 This is almost the same as decoding a bitstream from the start - the only differences are that:
 
   * The first frame has show_frame equal to 0.
- 
+
   * If frame_id_numbers_present_flag is equal to 1, for the first frame current_frame_id should not be compared to PrevFrameID (because PrevFrameID is uninitialized).
 
 ### Frame end update CDF process
@@ -532,7 +532,7 @@ the tile group syntax table.
 The frame CDF arrays are set equal to the saved CDF arrays as follows.
 
 A copy is made of the saved CDF values for each of the
-CDF arrays mentioned in the semantics for init_coeff_cdfs and init_non_coeff_cdfs. 
+CDF arrays mentioned in the semantics for init_coeff_cdfs and init_non_coeff_cdfs.
 The name of the destination for the copy is the name of the CDF array
 with no prefix.  The name of the source for the copy is the name of the CDF array
 prefixed with "Saved".
@@ -600,7 +600,7 @@ find_latest_backward() {
   ref = -1
   for ( i = 0; i < NUM_REF_FRAMES; i++ ) {
     hint = shiftedOrderHints[ i ]
-    if ( !usedFrame[ i ] && 
+    if ( !usedFrame[ i ] &&
          hint >= curFrameHint &&
          ( ref < 0 || hint >= latestOrderHint ) ) {
       ref = i
@@ -628,7 +628,7 @@ find_earliest_backward() {
   ref = -1
   for ( i = 0; i < NUM_REF_FRAMES; i++ ) {
     hint = shiftedOrderHints[ i ]
-    if ( !usedFrame[ i ] && 
+    if ( !usedFrame[ i ] &&
          hint >= curFrameHint &&
          ( ref < 0 || hint < earliestOrderHint ) ) {
       ref = i
@@ -679,7 +679,7 @@ find_latest_forward() {
   ref = -1
   for ( i = 0; i < NUM_REF_FRAMES; i++ ) {
     hint = shiftedOrderHints[ i ]
-    if ( !usedFrame[ i ] && 
+    if ( !usedFrame[ i ] &&
          hint < curFrameHint &&
          ( ref < 0 || hint >= latestOrderHint ) ) {
       ref = i
@@ -773,16 +773,16 @@ If useAlt2 is equal to 1, the following steps apply:
 
  * The projection process in [section 7.9.2][] is invoked with src equal to ALTREF2_FRAME, and dstSign equal to 1, and
    the output assigned to projOutput.
-   
+
  * If projOutput is equal to 1, refStamp is set equal to refStamp - 1.
 
 The variable useAlt is set equal to get_relative_dist( OrderHints[ ALTREF_FRAME ], OrderHint ) > 0.
 
 If useAlt is equal to 1 and (refStamp >= 0), the following steps apply:
 
- * The projection process in [section 7.9.2][] is invoked with src equal to ALTREF_FRAME, and dstSign equal to 1, 
+ * The projection process in [section 7.9.2][] is invoked with src equal to ALTREF_FRAME, and dstSign equal to 1,
    and the output assigned to projOutput.
-   
+
  * If projOutput is equal to 1, refStamp is set equal to refStamp - 1.
 
 If ( refStamp >= 0 ), the projection process in [section 7.9.2][] is invoked with
@@ -793,9 +793,9 @@ src equal to LAST2_FRAME, and dstSign equal to -1. (The output of this process i
 The inputs to this process are:
 
   - a variable src specifying which reference frame's motion vectors should be projected,
-  
+
   - a variable dstSign specifying a negation multiplier for the motion vector direction.
-  
+
 The process projects the motion vectors from a whole reference frame and stores the results in MotionFieldMvs.
 
 The process outputs a single boolean value representing whether the source frame was valid for this operation. If the output is zero, no modification is made to MotionFieldMvs.
@@ -852,15 +852,15 @@ The process now exits with the output set equal to 1.
 The inputs to this process are:
 
   - a length 2 array mv specifying a motion vector,
-  
+
   - a variable numerator specifying the number of frames to be covered by the projected motion vector,
-  
+
   - a variable denominator specifying the number of frames covered by the original motion vector.
-  
+
 The outputs of this process are:
 
   - a length 2 array projMv containing the projected motion vector
-  
+
 This process starts with a motion vector mv from a previous frame.
 This motion vector gives the displacement expected when moving a certain number of frames (given by the variable denominator).
 In order to use the motion vector for predictions using a different reference frame, the length of the motion vector must be scaled.
@@ -893,11 +893,11 @@ Div_Mult[32] = {
 The inputs to this process are:
 
   - variables x8 and y8 specifying a location in units of 8x8 luma samples,
-  
+
   - a variable dstSign specifying a negation multiplier for the motion vector direction,
-  
+
   - a length 2 array projMv specifying a projected motion vector.
-  
+
 The process generates global variables PosX8 and PosY8 representing the projected location in units of 8x8 luma samples.
 
 The process returns a flag posValid that indicates if the position should be used.
@@ -923,8 +923,8 @@ project( v8, delta, dstSign, max8, maxOff8 ) {
         offset8 = -( ( -delta ) >> ( 3 + 1 + MI_SIZE_LOG2 ) )
     }
     v8 += dstSign * offset8
-    if ( v8 < 0 || 
-         v8 >= max8 || 
+    if ( v8 < 0 ||
+         v8 >= max8 ||
          v8 < base8 - maxOff8 ||
          v8 >= base8 + 8 + maxOff8 ) {
         posValid = 0
@@ -957,7 +957,7 @@ The process also prepares the value of the contexts used
 when decoding inter prediction syntax elements.
 
 The array RefStackMv will be constructed during this process.
-RefStackMv[ idx ][ list ][ comp ] represents component comp (0 for y or 1 for x) of a motion vector for a particular list (0 or 1) at position idx (0 to MAX_REF_MV_STACK_SIZE - 1) in the stack.  No initialization is needed because each entry is always written before it can be read. 
+RefStackMv[ idx ][ list ][ comp ] represents component comp (0 for y or 1 for x) of a motion vector for a particular list (0 or 1) at position idx (0 to MAX_REF_MV_STACK_SIZE - 1) in the stack.  No initialization is needed because each entry is always written before it can be read.
 
 The variable bw4 specifying the width of the block in 4x4 luma samples is set equal to Num_4x4_Blocks_Wide[ MiSize ].
 
@@ -972,20 +972,20 @@ The following ordered steps apply:
 1. The setup global mv process specified in [section 7.10.2.1][] is invoked with the input 0 and the output is assigned to GlobalMvs[ 0 ].
 
 1. If isCompound is equal to 1, the setup global mv process specified in [section 7.10.2.1][] is invoked with the input 1 and the output is assigned to GlobalMvs[ 1 ].
-    
+
 1. The variable FoundMatch is set equal to 0.
 
-2. The scan row process in [section 7.10.2.2][] is invoked with deltaRow equal to -1 and isCompound as inputs. 
+2. The scan row process in [section 7.10.2.2][] is invoked with deltaRow equal to -1 and isCompound as inputs.
 
 2. The variable foundAboveMatch is set equal to FoundMatch, and FoundMatch is set equal to 0.
 
-3. The scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -1 and isCompound as inputs. 
+3. The scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -1 and isCompound as inputs.
 
 3. The variable foundLeftMatch is set equal to FoundMatch, and FoundMatch is set equal to 0.
 
 4. If Max( bw4, bh4 ) is less than or equal to 16, the scan point process in [section 7.10.2.4][] is invoked with deltaRow equal to -1, deltaCol equal to
    bw4, and isCompound as inputs.
-   
+
 4. If FoundMatch is equal to 1, the variable foundAboveMatch is set equal to 1.
 
 4. The variable CloseMatches (representing candidates found in the immediate neighborhood) is set equal to foundAboveMatch + foundLeftMatch.
@@ -1001,19 +1001,19 @@ The following ordered steps apply:
 5. If use_ref_frame_mvs is equal to 1,
 the temporal scan process in [section 7.10.2.5][] is invoked with isCompound as input (the temporal scan process affects ZeroMvContext).
 
-6. The scan point process in [section 7.10.2.4][] is invoked with deltaRow equal to -1, deltaCol equal to -1, and isCompound as inputs. 
+6. The scan point process in [section 7.10.2.4][] is invoked with deltaRow equal to -1, deltaCol equal to -1, and isCompound as inputs.
 
 6. If FoundMatch is equal to 1, the variable foundAboveMatch is set equal to 1.
 
 6. The variable FoundMatch is set equal to 0.
 
-7. The scan row process in [section 7.10.2.2][] is invoked with deltaRow equal to -3 and isCompound as inputs. 
+7. The scan row process in [section 7.10.2.2][] is invoked with deltaRow equal to -3 and isCompound as inputs.
 
 7. If FoundMatch is equal to 1, the variable foundAboveMatch is set equal to 1.
 
 7. The variable FoundMatch is set equal to 0.
 
-8. The scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -3 and isCompound as inputs. 
+8. The scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -3 and isCompound as inputs.
 
 8. If FoundMatch is equal to 1, the variable foundLeftMatch is set equal to 1.
 
@@ -1025,7 +1025,7 @@ the temporal scan process in [section 7.10.2.5][] is invoked with isCompound as 
 
 7. The variable FoundMatch is set equal to 0.
 
-10. If bw4 is greater than 1, the scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -5 and isCompound as inputs. 
+10. If bw4 is greater than 1, the scan col process in [section 7.10.2.3][] is invoked with deltaCol equal to -5 and isCompound as inputs.
 
 7. If FoundMatch is equal to 1, the variable foundLeftMatch is set equal to 1.
 
@@ -1087,9 +1087,9 @@ where the call to lower_mv_precision invokes the lower precision process specifi
 ##### Scan row process
 
 The inputs to this process are:
-  
+
   * a variable deltaRow specifying (in units of 4x4 luma samples) how far above to look for motion vectors,
-  
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
 
 The variable bw4 specifying the width of the block in 4x4 luma samples is set equal to Num_4x4_Blocks_Wide[ MiSize ].
@@ -1109,7 +1109,7 @@ at x offsets of -1, 0, 16, 32, 48 because the scan point process for the top-rig
 
 The variable deltaCol is set equal to 0.
 
-The variable useStep16 is set equal to (bw4 >= 16).  
+The variable useStep16 is set equal to (bw4 >= 16).
 
 **Note:** useStep16 is equal to 1 when the block is 64 luma samples wide or wider. This means
 only 4 locations will be searched in this case.  However, a 32 luma samples wide block
@@ -1153,9 +1153,9 @@ where the call to add_ref_mv_candidate invokes the process in [section 7.10.2.7]
 ##### Scan col process
 
 The inputs to this process are:
-  
+
   * a variable deltaCol specifying (in units of 4x4 luma samples) how far left to look for motion vectors,
-  
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
 
 The variable bh4 specifying the height of the block in 4x4 luma samples is set equal to Num_4x4_Blocks_High[ MiSize ].
@@ -1198,13 +1198,13 @@ where the call to add_ref_mv_candidate invokes the process in [section 7.10.2.7]
 ##### Scan point process
 
 The inputs to this process are:
-  
+
   * a variable deltaRow specifying (in units of 4x4 luma samples) how far above to look for a motion vector,
-  
+
   * a variable deltaCol specifying (in units of 4x4 luma samples) how far left to look for a motion vector,
- 
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
-  
+
 The variable mvRow is set equal to MiRow + deltaRow.
 
 The variable mvCol is set equal to MiCol + deltaCol.
@@ -1244,7 +1244,7 @@ where the call to add_tpl_ref_mv invokes the temporal sample process in [section
 The process then scans positions around the block (but still within the same superblock) as follows:
 
 ~~~~~ c
-allowExtension = ((bh4 >= Num_4x4_Blocks_High[BLOCK_8X8]) && 
+allowExtension = ((bh4 >= Num_4x4_Blocks_High[BLOCK_8X8]) &&
                   (bh4 < Num_4x4_Blocks_High[BLOCK_64X64]) &&
                   (bw4 >= Num_4x4_Blocks_Wide[BLOCK_8X8]) &&
                   (bw4 < Num_4x4_Blocks_Wide[BLOCK_64X64]))
@@ -1252,7 +1252,7 @@ if ( allowExtension ) {
     for ( i = 0; i < 3; i++ ) {
         deltaRow = tplSamplePos[ i ][ 0 ]
         deltaCol = tplSamplePos[ i ][ 1 ]
-        if ( check_sb_border( deltaRow, deltaCol ) ) { 
+        if ( check_sb_border( deltaRow, deltaCol ) ) {
             add_tpl_ref_mv( deltaRow, deltaCol, isCompound)
         }
     }
@@ -1271,9 +1271,9 @@ and check_sb_border checks that the position is within the same 64x64 block as f
 
 ~~~~~ c
 check_sb_border( deltaRow, deltaCol ) {
-    row = (MiRow & 15) + deltaRow 
+    row = (MiRow & 15) + deltaRow
     col = (MiCol & 15) + deltaCol
-    
+
     return ( row >= 0 && row < 16 && col >= 0 && col < 16 )
 }
 ~~~~~
@@ -1283,7 +1283,7 @@ check_sb_border( deltaRow, deltaCol ) {
 The inputs to this process are:
 
   * variables deltaRow and deltaCol specifying (in units of 4x4 luma samples) the offset to the candidate location,
- 
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
 
 This process looks up a motion vector from the motion field and adds it into the stack.
@@ -1312,7 +1312,7 @@ if ( !isCompound ) {
         return
     lower_mv_precision( candMv )
     if ( deltaRow == 0 && deltaCol == 0 ) {
-        if ( Abs( candMv[ 0 ] - GlobalMvs[ 0 ][ 0 ] ) >= 16 || 
+        if ( Abs( candMv[ 0 ] - GlobalMvs[ 0 ][ 0 ] ) >= 16 ||
              Abs( candMv[ 1 ] - GlobalMvs[ 0 ][ 1 ] ) >= 16 )
             ZeroMvContext = 1
         else
@@ -1340,9 +1340,9 @@ if ( !isCompound ) {
     lower_mv_precision( candMv0 )
     lower_mv_precision( candMv1 )
     if ( deltaRow == 0 && deltaCol == 0 ) {
-        if ( Abs( candMv0[ 0 ] - GlobalMvs[ 0 ][ 0 ] ) >= 16 || 
+        if ( Abs( candMv0[ 0 ] - GlobalMvs[ 0 ][ 0 ] ) >= 16 ||
              Abs( candMv0[ 1 ] - GlobalMvs[ 0 ][ 1 ] ) >= 16 ||
-             Abs( candMv1[ 0 ] - GlobalMvs[ 1 ][ 0 ] ) >= 16 || 
+             Abs( candMv1[ 0 ] - GlobalMvs[ 1 ][ 0 ] ) >= 16 ||
              Abs( candMv1[ 1 ] - GlobalMvs[ 1 ][ 1 ] ) >= 16 )
             ZeroMvContext = 1
         else
@@ -1372,13 +1372,13 @@ where the call to lower_mv_precision invokes the lower precision process specifi
 ##### Add reference motion vector process
 
 The inputs to this process are:
-  
+
   * variables mvRow and mvCol specifying (in units of 4x4 luma samples) the candidate location,
- 
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction,
-  
+
   * a variable weight specifying the weight attached to this motion vector.
-  
+
 This process examines the candidate to find matching reference frames.
 
 If IsInters[ mvRow ][ mvCol ] is equal to 0, this process terminates immediately.
@@ -1395,13 +1395,13 @@ the compound search stack process in [section 7.10.2.9][] is invoked with mvRow,
 ##### Search stack process
 
 The inputs to this process are:
-  
+
   * variables mvRow and mvCol specifying (in units of 4x4 luma samples) the candidate location,
-  
+
   * a variable candList specifying which list in the candidate matches our reference frame,
-  
+
   * a variable weight proportional to the corresponding block width or height for the candidate motion vector.
-  
+
 This process searches the stack for an exact match with a candidate motion vector.
 If present, the weight of the candidate motion vector is added to the weight of its counterpart in the stack,
 otherwise the process adds a motion vector to the stack.
@@ -1415,7 +1415,7 @@ The variable large is set equal to ( Min( Block_Width[ candSize ],Block_Height[ 
 The candidate motion vector candMv is set as follows:
 
   * If ( candMode == GLOBALMV \|\| candMode == GLOBAL_GLOBALMV) and ( GmType[ RefFrame[ 0 ] ] > TRANSLATION ) and ( large == 1 ), candMv is set equal to GlobalMvs[ 0 ].
-  
+
   * Otherwise, candMv is set equal to Mvs[ mvRow ][ mvCol ][ candList ].
 
 The lower precision process specified in [section 7.10.2.10][] is invoked with candMv.
@@ -1427,23 +1427,23 @@ The variable FoundMatch is set equal to 1.
 The process depends on whether the candidate motion vector is already in the stack as follows:
 
   * If candMv is already equal to RefStackMv[ idx ][ 0 ] for some idx less than NumMvFound, then WeightStack[ idx ] is increased by weight
-  
+
   * Otherwise, if NumMvFound is less than MAX_REF_MV_STACK_SIZE, the following ordered steps apply:
-   
+
      a. RefStackMv[ NumMvFound ][ 0 ] is set equal to candMv
-     
+
      b. WeightStack[ NumMvFound ] is set equal to weight
-     
+
      c. NumMvFound is set equal to NumMvFound + 1.
-     
+
   * Otherwise, (NumMvFound is greater than or equal to MAX_REF_MV_STACK_SIZE), the process has no effect.
 
 ##### Compound search stack process
 
 The inputs to this process are:
-  
+
   * variables mvRow and mvCol specifying (in units of 4x4 luma samples) the candidate location,
-  
+
   * a variable weight proportional to the corresponding block width or height for the candidate pair of motion vectors.
 
 This process searches the stack for an exact match with a candidate pair of motion vectors.
@@ -1467,28 +1467,28 @@ The variable FoundMatch is set equal to 1.
 The process depends on whether the candidate motion vector pair is already in the stack as follows:
 
   * If candMvs[ 0 ] is equal to RefStackMv[ idx ][ 0 ] and candMvs[ 1 ] is equal to RefStackMv[ idx ][ 1 ] for some idx less than NumMvFound, then WeightStack[ idx ] is increased by weight
-  
+
   * Otherwise, if NumMvFound is less than MAX_REF_MV_STACK_SIZE, the following ordered steps apply:
-   
+
      a. RefStackMv[ NumMvFound ][ i ] is set equal to candMvs[ i ] for i = 0..1
-     
+
      b. WeightStack[ NumMvFound ] is set equal to weight
-     
+
      c. NumMvFound is set equal to NumMvFound + 1.
-     
+
   * Otherwise, (NumMvFound is greater than or equal to MAX_REF_MV_STACK_SIZE), the process has no effect.
-  
+
 If has_newmv( candMode ) is equal to 1, NewMvCount is set equal to NewMvCount + 1.
-  
+
 The function has_newmv is defined as:
 
 ~~~~~
 has_newmv( mode ) {
-    return (mode == NEWMV || 
-            mode == NEW_NEWMV || 
-            mode == NEAR_NEWMV || 
+    return (mode == NEWMV ||
+            mode == NEW_NEWMV ||
+            mode == NEAR_NEWMV ||
             mode == NEW_NEARMV ||
-            mode == NEAREST_NEWMV || 
+            mode == NEAREST_NEWMV ||
             mode == NEW_NEARESTMV)
 }
 ~~~~~
@@ -1496,7 +1496,7 @@ has_newmv( mode ) {
 
 **Note:** It is impossible for mode to equal NEWMV in this function because it is only called for compound modes.
 {:.alert .alert-info }
-  
+
 ##### Lower precision process
 
 The input to this process is a reference candMv to a motion vector array.
@@ -1531,11 +1531,11 @@ if ( force_integer_mv ) {
 The inputs to this process are:
 
   * a variable start representing the first position to be sorted,
-  
+
   * a variable end representing the length of the array,
-  
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
-  
+
 This process performs a stable sort of part of the stack of motion vectors according to the corresponding weight.
 
 Entries in RefStackMv from start (inclusive) to end (exclusive) are sorted.
@@ -1571,7 +1571,7 @@ swap_stack( i, j ) {
   }
 }
 ~~~~~
-  
+
 ##### Extra search process
 
 The input to this process is a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
@@ -1591,7 +1591,7 @@ for ( list = 0; list < 2; list++ ) {
   RefDiffCount[ list ] = 0
 }
 ~~~~~
- 
+
 
 A two pass search for the partial matching candidates is specified as:
 
@@ -1620,7 +1620,7 @@ for ( pass = 0; pass < 2; pass++ ) {
       idx += Num_4x4_Blocks_High[ MiSizes[ mvRow ][ mvCol ] ]
     }
   }
-} 
+}
 ~~~~~
 
 The first pass searches the row above, the second searches the column to the left.
@@ -1682,9 +1682,9 @@ whereas for compound prediction NumMvFound will always be greater or equal to 2 
 ##### Add extra MV candidate process
 
 The inputs to this process are:
-  
+
   * variables mvRow and mvCol specifying (in units of 4x4 luma samples) the candidate location,
- 
+
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction.
 
 This process may modify the contents of the global variables
@@ -1733,15 +1733,15 @@ if ( isCompound ) {
       }
     }
   }
-} 
+}
 ~~~~~
- 
+
 ##### Context and clamping process
 
 The inputs to this process are:
 
   * a variable isCompound containing 0 for single prediction, or 1 to signal compound prediction,
-  
+
   * a variable numNew specifying the number of NEWMV candidates found in the immediate neighborhood.
 
 This process computes contexts to be used when decoding syntax elements, and clamps the candidates in RefStackMv.
@@ -1771,7 +1771,7 @@ for ( idx = 0; idx < NumMvFound ; idx++ ) {
         } else {
             z = 2
         }
-    }      
+    }
     DrlCtxStack[ idx ] = z
 }
 ~~~~~
@@ -1974,13 +1974,13 @@ cand[ 3 ] = midX * 8 + Mvs[ candRow ][ candCol ][ 0 ][ 1 ]
 ~~~~~
 
 The following ordered steps apply:
-  
+
   1. NumSamplesScanned is increased by 1.
-  
+
   2. If valid is equal to 0 and NumSamplesScanned is greater than 1, the process exits.
-  
+
   3. CandList[ NumSamples ][ j ] is set equal to cand[ j ] for j=0..3.
-  
+
   4. If valid is equal to 1, NumSamples is increased by 1.
 
 
@@ -2025,11 +2025,11 @@ The inputs to this process are:
 
   * a variable haveBelowLeft that is equal to 1 if there are valid samples to the
     left of the transform block below this transform block,
-    
+
   * a variable mode specifying the type of intra prediction to apply,
-    
+
   * a variable log2W specifying the base 2 logarithm of the width of the region to be predicted,
-  
+
   * a variable log2H specifying the base 2 logarithm of the height of the region to be predicted.
 
 The process makes use of the already reconstructed samples in the current frame CurrFrame to form a prediction for the current block.
@@ -2055,28 +2055,28 @@ The array AboveRow[ i ] for i = 0..w + h - 1 is derived as follows:
 
   * If haveAbove is equal to 0 and haveLeft is equal to 1, AboveRow[ i ] is set equal to 
     CurrFrame[ plane ][ y ][ x - 1 ].
-    
+
   * Otherwise, if haveAbove is equal to 0 and haveLeft is equal to 0, AboveRow[ i ] is set
     equal to ( 1 \<\< ( BitDepth - 1 ) ) - 1.
-    
+
   * Otherwise, the following applies:
-  
+
     * The variable aboveLimit is set equal to Min( maxX, x + ( haveAboveRight ? 2 * w : w ) - 1 ).
-    
+
     * AboveRow[ i ] is set equal to CurrFrame[ plane ][ y-1 ][ Min(aboveLimit, x+i) ].
-    
+
 The array LeftCol[ i ] for i = 0..w + h - 1 is derived as follows:
 
   * If haveLeft is equal to 0 and haveAbove is equal to 1, LeftCol[ i ] is set equal to 
     CurrFrame[ plane ][ y - 1 ][ x ].
-    
+
   * Otherwise, if haveLeft is equal to 0 and haveAbove is equal to 0, LeftCol[ i ] is set
     equal to ( 1 \<\< ( BitDepth - 1 ) ) + 1.
-    
+
   * Otherwise, the following applies:
-  
+
     * The variable leftLimit is set equal to Min( maxY, y + ( haveBelowLeft ? 2 * h : h ) - 1 ).
-    
+
     * LeftCol[ i ] is set equal to CurrFrame[ plane ][ Min(leftLimit, y+i) ][ x-1 ].
 
 The array AboveRow[ i ] for i = -1 is specified by:
@@ -2086,7 +2086,7 @@ The array AboveRow[ i ] for i = -1 is specified by:
 
   * Otherwise if haveAbove is equal to 1, AboveRow[ -1 ] is set equal to
     CurrFrame [ plane ][ y - 1 ][ x ].
-  
+
   * Otherwise if haveLeft is equal to 1, AboveRow[ -1 ] is set equal to
     CurrFrame [ plane ][ y ][ x - 1 ].
 
@@ -2097,35 +2097,35 @@ The array LeftCol[ i ] for i = -1 is set equal to AboveRow[ -1 ].
 A 2D array named pred containing the intra predicted samples is constructed as follows:
 
   * If plane is equal to 0 and use_filter_intra is true, the recursive intra prediction process specified in [section 7.11.2.3][] is invoked with w and h as inputs, and the output is assigned to pred.
-    
+
   * Otherwise, if is_directional_mode( mode ) is true, the directional intra prediction process specified in [section 7.11.2.4][] is invoked with plane, x, y, haveLeft, haveAbove, mode, w, h, maxX, maxY as inputs and the output is assigned to pred.
 
   * Otherwise if mode is equal to SMOOTH_PRED or SMOOTH_V_PRED or SMOOTH_H_PRED, the smooth intra prediction process specified in [section 7.11.2.6][] is invoked with mode, log2W, log2H, w, and h as inputs, and the output is assigned to pred.
 
   * Otherwise if mode is equal to DC_PRED, the DC intra prediction process specified in [section 7.11.2.5][] is invoked with haveLeft, haveAbove, log2W, log2H, w, and h as inputs and the output is assigned to pred.
-  
+
   * Otherwise (mode is equal to PAETH_PRED), the basic intra prediction process specified in [section 7.11.2.2][] is invoked with mode, w, and h as inputs, and the output is assigned to pred.
 
 The current frame is updated as follows:
 
   * CurrFrame[ plane ][ y + i ][ x + j ] is set equal to pred[ i ][ j ]
     for i = 0..h-1 and j = 0..w-1.
-    
+
 ##### Basic intra prediction process
 
 The inputs to this process are:
-  
+
   * a variable w specifying the width of the region to be predicted,
-  
+
   * a variable h specifying the height of the region to be predicted.
-  
+
 The output of this process is a 2D array named pred containing the intra predicted samples.
 
 The process generates filtered samples from the samples in LeftCol and AboveRow as follows:
 
   * The following ordered steps apply for i = 0..h-1, for j = 0..w-1:
 
-    1. The variable base is set equal to AboveRow[ j ] + LeftCol[ i ] - 
+    1. The variable base is set equal to AboveRow[ j ] + LeftCol[ i ] -
        AboveRow[ -1 ].
 
     2. The variable pLeft is set equal to Abs( base - LeftCol[ i ]).
@@ -2140,17 +2140,17 @@ The process generates filtered samples from the samples in LeftCol and AboveRow 
     6. Otherwise, if pTop <= pTopLeft, pred[ i ][ j ] is set equal to AboveRow[ j ].
 
     7. Otherwise, pred[ i ][ j ] is set equal to AboveRow[ -1 ].
-    
+
 The output of the process is the array pred.
-    
+
 ##### Recursive intra prediction process
 
 The inputs to this process are:
 
   * a variable w specifying the width of the region to be predicted,
-  
+
   * a variable h specifying the height of the region to be predicted.
-  
+
 The output of this process is a 2D array named pred containing the intra predicted samples.
 
 For each block of 4x2 samples, this process first prepares an array p of 7 neighboring samples, and then produces
@@ -2161,39 +2161,39 @@ The variable w4 is set equal to w \>\> 2.
 The variable h2 is set equal to h \>\> 1.
 
 The following steps apply for i2 = 0..h2-1, for j4 = 0..w4-1:
-    
+
   * The array p is derived as follows for i = 0..6:
-  
+
       * If i is less than 5, p[ i ] is derived as follows:
-      
+
           * If i2 is equal to 0, p[ i ] is set equal to AboveRow[ ( j4 \<\< 2 ) + i - 1 ].
-          
+
           * Otherwise, if j4 is equal to 0 and i is equal to 0, p[ i ] is set equal to LeftCol[ ( i2 \<\< 1 ) - 1 ].
-          
+
           * Otherwise, p[ i ] is set equal to pred[ ( i2 \<\< 1 ) - 1 ][ ( j4 \<\< 2 ) + i - 1 ].
-      
+
       * Otherwise (i is greater than or equal to 5), p[ i ] is derived as follows:
-      
+
           * If j4 is equal to 0, p[ i ] is set equal to LeftCol[ ( i2 \<\< 1 ) + i - 5 ].
-          
+
           * Otherwise (j4 is not equal to 0), p[ i ] is set equal to pred[ ( i2 \<\< 1 ) + i - 5 ][ ( j4 \<\< 2 ) - 1 ].
-  
+
   * The following steps apply for i1 = 0..1, j1 = 0..3:
-  
+
       * The variable pr is set equal to 0.
-      
+
       * The variable pr is incremented by Intra_Filter_Taps[ filter_intra_mode ][ ( i1 \<\< 2 ) + j1 ][ i ] * p[ i ] for i = 0..6.
-      
+
       * pred[ ( i2 \<\< 1 ) + i1 ][ ( j4 \<\< 2 ) + j1 ] is set equal to Clip1( Round2Signed( pr, INTRA_FILTER_SCALE_BITS ) ).
 
 The output of the process is the array pred.
-      
+
 ##### Directional intra prediction process
 
 The inputs to this process are:
 
   * a variable plane specifying which plane is being predicted,
-  
+
   * variables x and y specifying the location of the top left sample in the
     CurrFrame[ plane ] array of the current transform block,
 
@@ -2202,95 +2202,95 @@ The inputs to this process are:
 
   * a variable haveAbove that is equal to 1 if there are valid samples above
     this transform block,
-    
+
   * a variable mode specifying the type of intra prediction to apply,
-  
+
   * a variable w specifying the width of the region to be predicted,
-  
+
   * a variable h specifying the height of the region to be predicted,
-  
+
   * a variable maxX specifying the largest valid x coordinate for the current plane,
-  
+
   * a variable maxY specifying the largest valid y coordinate for the current plane.
-  
+
 The output of this process is a 2D array named pred containing the intra predicted samples.
 
 The process uses a directional filter to generate filtered samples from the samples in LeftCol and AboveRow.
-  
+
 The following ordered steps apply:
-  
+
   1. The variable angleDelta is derived as follows:
-    
+
       * If plane is equal to 0, angleDelta is set equal to AngleDeltaY.
 
       * Otherwise (plane is not equal to 0), angleDelta is set equal to AngleDeltaUV.
-     
+
   2. The variable pAngle is set equal to ( Mode_To_Angle[ mode ] + angleDelta * ANGLE_STEP ).
-  
+
   3. The variables upsampleAbove and upsampleLeft are set equal to 0.
-  
+
   4. If enable_intra_edge_filter is equal to 1, the following applies:
-  
+
       * If pAngle is not equal to 90 and pAngle is not equal to 180, the following applies:
-      
+
           * If (pAngle > 90) and (pAngle < 180) and (w + h) >= 24), the
             filter corner process specified in [section 7.11.2.7][] is invoked and the output assigned to both LeftCol[ -1 ] and AboveRow[ -1 ].
-            
+
           * The intra filter type process specified in [section 7.11.2.8][] is invoked with the input variable plane and the output assigned to
             filterType.
-          
+
           * If haveAbove is equal to 1, the following steps apply:
-          
+
               * The intra edge filter strength selection process specified in [section 7.11.2.9][] is invoked
                 with w, h, filterType, and pAngle - 90 as inputs, and the output assigned to the variable strength.
-                
+
               * The variable numPx is set equal to Min( w, ( maxX - x + 1 ) ) + ( pAngle < 90 ? h : 0 ) + 1.
-                
+
               * The intra edge filter process specified in [section 7.11.2.12][] is invoked with the parameters
                 numPx, strength, and 0 as inputs.
-                
+
           * If haveLeft is equal to 1, the following steps apply:
-          
+
               * The intra edge filter strength selection process specified in [section 7.11.2.9][] is invoked
                 with w, h, filterType, and pAngle - 180 as inputs, and the output assigned to the variable strength.
-                
+
               * The variable numPx is set equal to Min( h, ( maxY - y + 1 ) ) + ( pAngle > 180 ? w : 0 ) + 1.
-                
+
               * The intra edge filter process specified in [section 7.11.2.12][] is invoked with the parameters
                 numPx, strength, and 1 as inputs.
-                
+
       * The intra edge upsample selection process specified in [section 7.11.2.10][] is invoked with w, h, filterType, and pAngle - 90 as inputs,
         and the output assigned to the variable upsampleAbove.
-      
+
       * The variable numPx is set equal to ( w + (pAngle < 90 ? h : 0) ).
-        
+
       * If upsampleAbove is equal to 1, the intra edge upsample process specified in [section 7.11.2.11][] is invoked with the parameters numPx and 0 as inputs.
-      
+
       * The intra edge upsample selection process specified in [section 7.11.2.10][] is invoked with w, h, filterType, and pAngle - 180 as inputs,
         and the output assigned to the variable upsampleLeft.
-        
+
       * The variable numPx is set equal to ( h + (pAngle > 180 ? w : 0) ).
-      
+
       * If upsampleLeft is equal to 1, the intra edge upsample process specified in [section 7.11.2.11][] is invoked with the parameters numPx and 1 as inputs.
-  
+
   5. The variable dx is derived as follows:
-  
+
       * If pAngle is less than 90, dx is set equal to Dr_Intra_Derivative[ pAngle ].
-      
+
       * Otherwise, if pAngle is greater than 90 and less than 180, dx is set equal to Dr_Intra_Derivative[ 180 - pAngle ].
-      
+
       * Otherwise, dx is undefined.
-  
+
   6. The variable dy is derived as follows:
-  
+
       * If pAngle is greater than 90 and less than 180, dy is set equal to Dr_Intra_Derivative[ pAngle - 90 ].
-      
+
       * Otherwise, if pAngle is greater than 180, dy is set equal to Dr_Intra_Derivative[ 270 - pAngle ].
-      
+
       * Otherwise, dy is undefined.
-    
+
   7. If pAngle is less than 90, the following steps apply for i = 0..h-1, for j = 0..w-1:
-  
+
       * The variable idx is set equal to ( i + 1 ) * dx.
 
       * The variable base is set equal to (idx \>\> ( 6 - upsampleAbove ) ) + (j \<\< upsampleAbove).
@@ -2302,13 +2302,13 @@ The following ordered steps apply:
       * If base is less than maxBaseX, pred[ i ][ j ] is set equal to Round2( AboveRow[ base ] * ( 32 - shift ) + AboveRow[ base + 1 ] * shift, 5 ).
 
       * Otherwise (base is greater than or equal to maxBaseX), pred[ i ][ j ] is set equal to AboveRow[ maxBaseX ].
-    
+
   8. Otherwise, if pAngle is greater than 90 and pAngle is less than 180, the following steps apply for i = 0..h-1, for j = 0..w-1:
-  
+
       * The variable idx is set equal to ( j \<\< 6 ) - ( i + 1 ) * dx.
-      
+
       * The variable base is set equal to idx \>\> ( 6 - upsampleAbove ).
-      
+
       * If base is greater than or equal to -(1 \<\< upsampleAbove), the following steps apply:
 
         * The variable shift is set equal to ( ( idx \<\< upsampleAbove ) \>\> 1 ) & 0x1F.
@@ -2316,28 +2316,28 @@ The following ordered steps apply:
         * pred[ i ][ j ] is set equal to Round2( AboveRow[ base ] * ( 32 - shift ) + AboveRow[ base + 1 ] * shift, 5 ).
 
       * Otherwise (base is less than -(1 \<\< upsampleAbove), the following steps apply:
-      
+
         * The variable idx is set equal to ( i \<\< 6 ) - ( j + 1 ) * dy.
-        
+
         * The variable base is set equal to idx \>\> ( 6 - upsampleLeft ).
-        
+
         * The variable shift is set equal to ( ( idx \<\< upsampleLeft ) \>\> 1 ) & 0x1F.
-        
+
         * pred[ i ][ j ] is set equal to Round2( LeftCol[ base ] * ( 32 - shift ) + LeftCol[ base + 1 ] * shift, 5 ).
-      
+
   9. Otherwise, if pAngle is greater than 180, the following steps apply for i = 0..h-1, for j = 0..w-1:
-  
+
       * The variable idx is set equal to ( j + 1 ) * dy.
-      
+
       * The variable base is set equal to ( idx \>\> ( 6 - upsampleLeft ) ) + ( i \<\< upsampleLeft ).
-      
+
       * The variable shift is set equal to ( ( idx \<\< upsampleLeft ) \>\> 1 ) & 0x1F.
-      
+
       * pred[ i ][ j ] is set equal to Round2( LeftCol[ base ] * ( 32 - shift ) + LeftCol[ base + 1 ] * shift, 5 ).
-    
+
   10. Otherwise, if pAngle is equal to 90, pred[ i ][ j ] is set equal to AboveRow[ j ] with j = 0..w-1 and i = 0..h-1 (each row of the block is filled with
       a copy of AboveRow).
-     
+
   11. Otherwise, if pAngle is equal to 180, pred[ i ][ j ] is set equal to LeftCol[ i ] with j = 0..w-1 and i = 0..h-1 (each column of the block is filled with
       a copy of LeftCol).
 
@@ -2352,15 +2352,15 @@ The inputs to this process are:
 
   * a variable haveAbove that is equal to 1 if there are valid samples above
     this transform block,
-    
+
   * a variable log2W specifying the base 2 logarithm of the width of the region to be predicted,
-  
+
   * a variable log2H specifying the base 2 logarithm of the height of the region to be predicted,
-    
+
   * a variable w specifying the width of the region to be predicted,
-  
+
   * a variable h specifying the height of the region to be predicted.
-  
+
 The output of this process is a 2D array named pred containing the intra predicted samples.
 
 The process averages the available edge samples in LeftCol and AboveRow to generate the prediction as follows:
@@ -2376,11 +2376,11 @@ The process averages the available edge samples in LeftCol and AboveRow to gener
         sum += LeftCol[ k ]
     for ( k = 0; k < w; k++ )
         sum += AboveRow[ k ]
-    
+
     sum += ( w + h ) >> 1
     avg = sum / ( w + h )
     ~~~~~
-    
+
 **Note:** The reference code shows how the division by (w+h) can be implemented with multiplication and shift operations.
 {:.alert .alert-info }
 
@@ -2412,7 +2412,7 @@ The process averages the available edge samples in LeftCol and AboveRow to gener
 
   * Otherwise (haveLeft is equal to 0 and haveAbove is equal to 0), pred[ i ][ j ] is set equal
     to 1 \<\< ( BitDepth - 1 ) with i = 0..h-1 and j = 0..w-1.
-    
+
 The output of the process is the array pred.
 
 ##### Smooth intra prediction process
@@ -2420,15 +2420,15 @@ The output of the process is the array pred.
 The inputs to this process are:
 
   * a variable mode specifying the type of intra prediction to apply,
-  
+
   * a variable log2W specifying the base 2 logarithm of the width of the region to be predicted,
-  
+
   * a variable log2H specifying the base 2 logarithm of the height of the region to be predicted,
-  
+
   * a variable w specifying the width of the region to be predicted,
-  
+
   * a variable h specifying the height of the region to be predicted.
-  
+
 The output of this process is a 2D array named pred containing the intra predicted samples.
 
 The process uses linear interpolation to generate filtered samples from the samples in LeftCol and AboveRow as follows:
@@ -2447,7 +2447,7 @@ The process uses linear interpolation to generate filtered samples from the samp
        |        5 | Sm_Weights_Tx_32x32 |
        |        6 | Sm_Weights_Tx_64x64 |
        {:.table .table-sm .table-bordered }
-    
+
     2. The array smWeightsY is set dependent on the value of log2H according to the
        following table:
 
@@ -2459,9 +2459,9 @@ The process uses linear interpolation to generate filtered samples from the samp
        |        5 | Sm_Weights_Tx_32x32 |
        |        6 | Sm_Weights_Tx_64x64 |
        {:.table .table-sm .table-bordered }
-       
+
     3. The variable smoothPred is set as follows:
-    
+
        ~~~~~ c
        smoothPred =   smWeightsY[ i ] * AboveRow[ j ] +
                    ( 256 - smWeightsY[ i ] ) * LeftCol[ h - 1 ] +
@@ -2485,9 +2485,9 @@ The process uses linear interpolation to generate filtered samples from the samp
        |        5 | Sm_Weights_Tx_32x32 |
        |        6 | Sm_Weights_Tx_64x64 |
        {:.table .table-sm .table-bordered }
-    
+
     2. The variable smoothPred is set as follows:
-    
+
        ~~~~~ c
        smoothPred =   smWeights[ i ] * AboveRow[ j ] +
                    ( 256 - smWeights[ i ] ) * LeftCol[ h - 1 ]
@@ -2509,16 +2509,16 @@ The process uses linear interpolation to generate filtered samples from the samp
        |        5 | Sm_Weights_Tx_32x32 |
        |        6 | Sm_Weights_Tx_64x64 |
        {:.table .table-sm .table-bordered }
-    
+
     2. The variable smoothPred is set as follows:
-    
+
        ~~~~~ c
        smoothPred =   smWeights[ j ] * LeftCol[ i ] +
                    ( 256 - smWeights[ j ] ) * AboveRow[ w - 1 ]
        ~~~~~
 
     3. pred[ i ][ j ] is set equal to Round2( smoothPred, 8 ).
-    
+
 The output of the process is the array pred.
 
 ##### Filter corner process
@@ -2589,9 +2589,9 @@ is_smooth( row, col, plane ) {
 The inputs to this process are:
 
   * a variable w containing the width of the transform in samples,
-  
+
   * a variable h containing the height of the transform in samples,
-  
+
   * a variable filterType that is 0 or 1 that controls the strength of filtering,
 
   * a variable delta containing an angle difference in degrees.
@@ -2645,9 +2645,9 @@ if ( filterType == 0 ) {
 The inputs to this process are:
 
   * a variable w containing the width of the transform in samples,
-  
+
   * a variable h containing the height of the transform in samples,
-  
+
   * a variable filterType that is 0 or 1 that controls the strength of filtering,
 
   * a variable delta containing an angle difference in degrees.
@@ -2675,17 +2675,17 @@ if ( d <= 0 || d >= 40 ) {
 The inputs to this process are:
 
   * a variable numPx specifying the number of samples to filter,
-  
+
   * a variable dir containing 0 when filtering the above samples, and 1 when filtering the left samples.
-  
+
 The output of this process are upsampled samples in the AboveRow and LeftCol arrays.
 
 The variable buf is set depending on dir:
 
   * If dir is equal to 0, buf is set equal to a reference to AboveRow.
-  
+
   * Otherwise (dir is equal to 1), buf is set equal to a reference to LeftCol.
-  
+
 **Note:** buf is a reference to either AboveRow or LeftCol.
 "reference" indicates that modifying values in buf modifies values in the original array.
 {:.alert .alert-info }
@@ -2720,12 +2720,12 @@ for ( i = 0; i < numPx; i++ ) {
 The inputs to this process are:
 
   * a size sz (sz will always be less than or equal to 129),
-  
+
   * a filter strength strength between 0 and 3 inclusive,
-  
+
   * an edge direction left (when equal to 1, it specifies a vertical edge; when equal to 0, it specifies
     a horizontal edge.
-  
+
 The process filters the LeftCol (if left is equal to 1) or AboveRow (if left is equal to 0) arrays.
 
 If strength is equal to 0, the process returns without doing anything.
@@ -2735,15 +2735,15 @@ The array edge is derived by setting edge[ i ] equal to ( left ? LeftCol[ i - 1 
 Otherwise (strength is not equal to 0), the following ordered steps apply for i = 1..sz-1:
 
   1. The variable s is set equal to 0.
-  
+
   2. The following steps now apply for j = 0..INTRA_EDGE_TAPS-1.
-  
+
       a. The variable k is set equal to Clip3( 0, sz - 1, i - 2 + j ).
-      
+
       b. The variable s is incremented by Intra_Edge_Kernel[ strength - 1 ][ j ] * edge[ k ].
-      
+
   3. If left is equal to 1, LeftCol[ i - 1 ] is set equal to ( s + 8 ) \>\> 4.
-  
+
   4. If left is equal to 0, AboveRow[ i - 1 ] is set equal to ( s + 8 ) \>\> 4.
 
 The array Intra_Edge_Kernel is specified as follows:
@@ -2771,61 +2771,61 @@ to this process are:
 
   * variables w and h specifying the width and height of the region to be
     predicted,
-    
+
   * variables candRow and candCol specifying the location (in units of 4x4 blocks) of the motion vector information to be used.
-    
+
 The outputs of this process are
 predicted samples in the current frame CurrFrame.
 
 This process is triggered by a function call to predict_inter.
 
-The variable isCompound is set equal to RefFrames[ candRow ][ candCol ][ 1 ] > INTRA_FRAME. 
+The variable isCompound is set equal to RefFrames[ candRow ][ candCol ][ 1 ] > INTRA_FRAME.
 
 The prediction arrays are formed by
 the following ordered steps:
 
   1. The rounding variables derivation process specified in [section 7.11.3.2][] is invoked with the variable isCompound as input.
-  
+
   2. If plane is equal to 0 and motion_mode is equal to LOCALWARP, the warp estimation process in [section 7.11.3.8][] is invoked.
-  
+
   3. If plane is equal to 0 and motion_mode is equal to LOCALWARP and LocalValid is equal to 1, the setup shear process
      specified in [section 7.11.3.6][] is invoked with LocalWarpParams as input,
      and the output warpValid is assigned to LocalValid (the other outputs are discarded).
-  
+
   4. The variable refList is set equal to 0.
-  
+
   5. The variable refFrame is set equal to RefFrames[ candRow ][ candCol ][ refList ].
-  
+
   6. If (YMode == GLOBALMV \|\| YMode == GLOBAL_GLOBALMV) and GmType[ refFrame ] > TRANSLATION, the setup shear process
      specified in [section 7.11.3.6][] is invoked with gm_params[ refFrame ] as input,
      and the output warpValid is assigned to globalValid (the other outputs are discarded).
-  
+
   7. The variable useWarp (a value of 1 indicates local warping, 2 indicates global warping) is derived as follows:
-  
+
      * If w < 8 or h < 8, useWarp is set equal to 0.
-     
+
      * Otherwise, if force_integer_mv is equal to 1, useWarp is set equal to 0.
-    
+
      * Otherwise, if motion_mode is equal to LOCALWARP and LocalValid is equal to 1, useWarp is set equal to 1.
-     
+
      * Otherwise, if all of the following are true, useWarp is set equal to 2.
-     
+
         * (YMode == GLOBALMV \|\| YMode == GLOBAL_GLOBALMV).
-        
+
         * GmType[ refFrame ] > TRANSLATION.
-        
+
         * is_scaled( refFrame ) is equal to 0.
-        
+
         * globalValid is equal to 1.
-    
+
      * Otherwise, useWarp is set equal to 0.
-     
+
   8. The motion vector array mv is set equal to Mvs[ candRow ][ candCol ][ refList ].
-     
+
   9. The variable refIdx specifying which reference frame is being used is set as follows:
-  
+
      * If use_intrabc is equal to 0, refIdx is set equal to ref_frame_idx[ refFrame - LAST_FRAME ].
-     
+
      * Otherwise (use_intrabc is equal to 1), refIdx is set equal to -1 and RefFrameWidth[ -1 ] is set equal to FrameWidth, RefFrameHeight[ -1 ] is set equal
        to FrameHeight, and RefUpscaledWidth[ -1 ] is set equal to UpscaledWidth.
        (These values ensure that the motion vector scaling has no effect.)
@@ -2833,12 +2833,12 @@ the following ordered steps:
   10. The motion vector scaling process in [section 7.11.3.3][] is invoked with
      plane, refIdx, x, y, mv as inputs and the output being the
      initial location startX, startY, and the step sizes stepX, stepY.
-     
+
   11. If use_intrabc is equal to 1, RefFrameWidth[ -1 ] is set equal to  MiCols * MI_SIZE,
       RefFrameHeight[ -1 ] is set equal to MiRows * MI_SIZE,
       and RefUpscaledWidth[ -1 ] is set equal to  MiCols * MI_SIZE.
       (These values are needed to avoid intrabc prediction being cropped to the frame boundaries.)
-     
+
   12. If useWarp is not equal to 0, the block warp process in [section 7.11.3.5][] is invoked with
      useWarp, plane, refList, x, y, i8, j8, w, h as inputs and the
      output is merged into the 2D array preds[ refList ] for i8 = 0..((h-1) \>\> 3) and for j8 = 0..((w-1) \>\> 3).
@@ -2851,19 +2851,19 @@ the following ordered steps:
   14. If isCompound is equal to 1, then the variable refList is set equal
      to 1 and steps 5 to 13 are repeated to form the prediction for
      the second reference.
-     
+
 An array named Mask is prepared as follows:
 
   * If compound_type is equal to COMPOUND_WEDGE and plane is equal to 0, the wedge mask process in [section 7.11.3.11][] is invoked with w, h as inputs.
-  
+
   * Otherwise if compound_type is equal to COMPOUND_INTRA, the intra mode variant mask process in [section 7.11.3.13][] is invoked with w, h as inputs.
-  
+
   * Otherwise if compound_type is equal to COMPOUND_DIFFWTD and plane is equal to 0, the difference weight mask process in [section 7.11.3.12][] is invoked with preds, w, h as inputs.
-  
+
   * Otherwise, no mask array is needed.
-  
+
 If compound_type is equal to COMPOUND_DISTANCE, the distance weights process in [section 7.11.3.15][] is invoked with candRow and candCol as inputs.
-     
+
 The inter predicted samples are then derived as
 follows:
 
@@ -2873,13 +2873,13 @@ follows:
   * Otherwise if compound_type is equal to COMPOUND_AVERAGE, CurrFrame[ plane ][ y + i ][ x + j ] is set equal to
    Clip1( Round2( preds[ 0 ][ i ][ j ] + preds[ 1 ][ i ][ j ], 1 + InterPostRound ) )
    for i = 0..h-1 and j = 0..w-1.
-   
+
   * Otherwise if compound_type is equal to COMPOUND_DISTANCE, CurrFrame[ plane ][ y + i ][ x + j ] is set equal to
    Clip1( Round2( FwdWeight * preds[ 0 ][ i ][ j ] + BckWeight * preds[ 1 ][ i ][ j ], 4 + InterPostRound ) )
    for i = 0..h-1 and j = 0..w-1.
-   
+
   * Otherwise, the mask blend process in [section 7.11.3.14][] is invoked with preds, plane, x, y, w, h as inputs.
-   
+
 If motion_mode is equal to OBMC, the overlapped motion compensation in [section 7.11.3.9][] is invoked with plane, w, h as inputs.
 
 ##### Rounding variables derivation process
@@ -2907,7 +2907,7 @@ The rounding variables InterRound0, InterRound1, and InterPostRound are derived 
 The inputs to this process are:
 
   * a variable plane specifying which plane is being predicted,
-    
+
   * a variable refIdx specifying which reference frame is being used,
 
   * variables x and y specifying the location of the top left sample in the
@@ -2958,7 +2958,7 @@ plane as follows:
 
   * Otherwise, subX is set equal to subsampling_x and subY is set equal to
    subsampling_y.
-   
+
 The variable halfSample (representing half the size of a sample in units of 1/16 th of a sample) is set equal to ( 1 \<\< ( SUBPEL_BITS - 1 ) ).
 
 The variable origX is set equal to ( (x \<\< SUBPEL_BITS) + ( ( 2 * mv[1] ) \>\> subX ) + halfSample ).
@@ -2996,7 +2996,7 @@ The output variable stepY is set equal to Round2Signed( yScale, REF_SCALE_SHIFT 
 The inputs to this process are:
 
   * a variable plane,
-  
+
   * a variable refIdx specifying which reference frame is being used (or -1 for intra block copy),
 
   * variables x and y giving the block location with in units of 1/1024 th of a
@@ -3007,7 +3007,7 @@ The inputs to this process are:
 
   * variables w and h giving the width and height of the block in units of
     samples,
-    
+
   * variables candRow and candCol specifying the location (in units of 4x4 blocks) of the motion vector information to be used.
 
 The output from this process is the 2D array named pred containing inter
@@ -3016,7 +3016,7 @@ predicted samples.
 A variable ref specifying the reference frame contents is set as follows:
 
   * If refIdx is equal to -1, ref is set equal to CurrFrame.
-  
+
   * Otherwise (refIdx is greater than or equal to 0), ref is set equal to FrameStore[ refIdx ].
 
 The variables subX and subY are set equal to the subsampling for the current
@@ -3220,15 +3220,15 @@ The filter at index 5 has a four tap version of the EIGHTAP_SMOOTH filter.
 The inputs to this process are:
 
   * a variable useWarp (equal to 1 for local warp, or 2 for global warp),
-  
+
   * a variable plane,
 
   * a variable refList specifying that the process should predict from
     RefFrame[ refList ],
-    
+
   * variables x and y specifying the location of the top left sample in the
     CurrFrame[ plane ] array of the region to be predicted,
-    
+
   * variables i8 and j8 specifying the offset (in units of 8 samples) relative to the top left sample,
 
   * variables w and h giving the width and height of the block in units of
@@ -3297,14 +3297,14 @@ The filtering is applied as follows:
     sx4 = x4 & ((1 << WARPEDMODEL_PREC_BITS) - 1)
     iy4 = y4 >> WARPEDMODEL_PREC_BITS
     sy4 = y4 & ((1 << WARPEDMODEL_PREC_BITS) - 1)
-    
+
     for ( i1 = -7; i1 < 8; i1++ ) {
         for ( i2 = -4; i2 < 4; i2++ ) {
             sx = sx4 + alpha * i2 + beta * i1
             offs = Round2(sx, WARPEDDIFF_PREC_BITS) + WARPEDPIXEL_PREC_SHIFTS
             s = 0
             for ( i3 = 0; i3 < 8; i3++ ) {
-                s += Warped_Filters[ offs ][ i3 ] * 
+                s += Warped_Filters[ offs ][ i3 ] *
                   ref[ plane ][ Clip3( 0, lastY, iy4 + i1 ) ]
                               [ Clip3( 0, lastX, ix4 + i2 - 3 + i3 ) ]
             }
@@ -3312,17 +3312,17 @@ The filtering is applied as follows:
         }
     }
     ~~~~~
-    
+
   * The array pred is specified as follows:
 
-    ~~~~~ c 
+    ~~~~~ c
     for ( i1 = -4; i1 < Min(4, h - i8 * 8 - 4); i1++ ) {
         for ( i2 = -4; i2 < Min(4, w - j8 * 8 - 4); i2++ ) {
             sy = sy4 + gamma * i2 + delta * i1
             offs = Round2(sy, WARPEDDIFF_PREC_BITS) + WARPEDPIXEL_PREC_SHIFTS
             s = 0
             for ( i3 = 0; i3 < 8; i3++ ) {
-                s += Warped_Filters[offs][i3] * 
+                s += Warped_Filters[offs][i3] *
                      intermediate[(i1 + i3 + 4)][(i2 + 4)]
             }
             pred[ i8 * 8 + i1 + 4 ][ j8 * 8 + i2 + 4 ] = Round2(s, InterRound1)
@@ -3432,7 +3432,7 @@ The filtering is applied as follows:
         { 0, 0, 1, - 4,  13, 124, - 7, 1 }, { 0, 0, 1, - 4,  11, 125, - 6, 1 },
         { 0, 0, 1, - 3,   8, 126, - 5, 1 }, { 0, 0, 1, - 2,   6, 126, - 4, 1 },
         { 0, 0, 0, - 1,   4, 127, - 3, 1 }, { 0, 0, 0,   0,   2, 127, - 1, 0 },
-        
+
         { 0, 0, 0,   0,   2, 127, - 1, 0 }
     }
     ~~~~~
@@ -3469,9 +3469,9 @@ delta = Round2Signed( delta0, WARP_PARAM_REDUCE_BITS ) << WARP_PARAM_REDUCE_BITS
 The output warpValid is set as follows:
 
   * If 4 * Abs( alpha ) + 7 * Abs( beta ) is greater than or equal to (1 \<\< WARPEDMODEL_PREC_BITS), warpValid is set equal to 0.
-  
+
   * If 4 * Abs( gamma ) + 4 * Abs( delta ) is greater than or equal to (1 \<\< WARPEDMODEL_PREC_BITS), warpValid is set equal to 0.
-  
+
   * Otherwise, warpValid is set equal to 1.
 
 ##### Resolve divisor process
@@ -3487,15 +3487,15 @@ The variable e is set equal to Abs( d ) - ( 1 \<\< n ).
 The variable f is set as follows:
 
   * If n > DIV_LUT_BITS, f is set equal to Round2( e, n - DIV_LUT_BITS ).
-  
+
   * Otherwise, f is set equal to e \<\< ( DIV_LUT_BITS - n ).
-  
+
 The output variable divShift is set equal to ( n + DIV_LUT_PREC_BITS ).
 
 The output variable divFactor is set as follows:
 
   * If d is less than 0, divFactor is set equal to -Div_Lut[ f ].
-  
+
   * Otherwise, divFactor is set equal to Div_Lut[ f ].
 
 The lookup table Div_Lut is specified as:
@@ -3586,9 +3586,9 @@ The variable det (containing the determinant of the matrix A) is set equal to A[
 The variable LocalValid is set as follows:
 
   * If det is equal to 0, LocalValid is set equal to 0.
-  
+
   * Otherwise, LocalValid is set equal to 1.
-  
+
 If det is equal to 0, this process terminates at this point.
 
 The resolve divisor process specified in [section 7.11.3.7][] is invoked with det as input, and the outputs assigned to divShift and divFactor.
@@ -3641,7 +3641,7 @@ to this process are:
 
   * variables w and h specifying the width and height of the region to be
     predicted.
-    
+
 The outputs of this process are modified inter
 predicted samples in the current frame CurrFrame.
 
@@ -3714,11 +3714,11 @@ if ( AvailL ) {
 When the function predict_overlap is invoked, the following ordered steps apply to form the overlap prediction for a region of size predW by predH based on the candidate motion vector:
 
   1. The motion vector mv is set equal to Mvs[ candRow ][ candCol ][ 0 ].
-  
+
   2. The variable refIdx is set equal to ref_frame_idx[ RefFrames[ candRow ][ candCol ][ 0 ] - LAST_FRAME ].
-  
+
   3. The variable predX is set equal to (x4 * 4) \>\> subX.
-  
+
   4. The variable predY is set equal to (y4 * 4) \>\> subY.
 
   5. The motion vector scaling process in [section 7.11.3.3][] is invoked with
@@ -3728,11 +3728,11 @@ When the function predict_overlap is invoked, the following ordered steps apply 
   6. The block inter prediction process in [section 7.11.3.4][] is invoked with
      plane, refIdx, startX, startY, stepX, stepY, predW, predH, candRow, candCol as inputs and the
      output is assigned to the 2D array obmcPred.
-     
+
   7. obmcPred[ i ][ j ] is set equal to Clip1( obmcPred[ i ][ j ] ) for i = 0..predH-1 and j = 0..predW-1.
-  
+
   8. The blending process in [section 7.11.3.10][] is invoked with plane, predX, predY, predW, predH, pass, obmcPred, and mask as inputs.
-  
+
 The function get_obmc_mask returns a blending mask as follows:
 
 ~~~~~ c
@@ -3781,13 +3781,13 @@ to this process are:
 
   * variables predW and predH specifying the width and height of the region to be
     predicted,
-    
+
   * a variable pass equal to 0 if blending above samples, or equal to 1 if blending left samples,
-  
+
   * a 2d array obmcPred containing the samples predicted from a neighboring motion vector,
-  
+
   * an array mask containing the blending weights.
-    
+
 The outputs of this process are modified inter
 predicted samples in the current frame CurrFrame.
 
@@ -3796,12 +3796,12 @@ For i = 0..(predH - 1) and j = 0..(predW - 1), the following ordered steps apply
   1. The variable m specifying the blending factor is specifed as follows:
 
      * If pass is equal to 0 (blend from above), m is set equal to mask[ i ].
-    
+
      * Otherwise (pass is equal to 1 meaning blend from left), m is set equal to mask[ j ].
 
   2. CurrFrame[ plane ][ predY + i ][ predX + j ] is set equal to
     Round2( m * CurrFrame[ plane ][ predY + i ][ predX + j ] + (64 - m) * obmcPred[ i ][ j ], 6)
-    
+
 ##### Wedge mask process
 
 The input to this process is:
@@ -3960,22 +3960,22 @@ Wedge_Codebook[3][16][3] = {
 
 The wedge direction constants used above are defined as follows:
 
-| Constant         | Value 
+| Constant         | Value
 |:----------------:|:------:
-| WEDGE_HORIZONTAL | 0     
-| WEDGE_VERTICAL   | 1     
-| WEDGE_OBLIQUE27  | 2     
-| WEDGE_OBLIQUE63  | 3     
-| WEDGE_OBLIQUE117 | 4     
-| WEDGE_OBLIQUE153 | 5     
+| WEDGE_HORIZONTAL | 0
+| WEDGE_VERTICAL   | 1
+| WEDGE_OBLIQUE27  | 2
+| WEDGE_OBLIQUE63  | 3
+| WEDGE_OBLIQUE117 | 4
+| WEDGE_OBLIQUE153 | 5
 {:.table .table-sm .table-bordered }
 
 ##### Difference weight mask process
 
 The input to this process is:
- 
+
   * an array preds containing the predicted samples,
-  
+
   * variables w and h specifying the width and height of the region to be
   predicted.
 
@@ -4046,7 +4046,7 @@ Ii_Weights_1d[MAX_SB_SIZE] = {
 The inputs to this process are
 
   * an array preds containing the predicted samples,
-  
+
   * a variable plane specifying which plane is being predicted,
 
   * variables dstX and dstY specifying the location of the top left sample in the
@@ -4054,8 +4054,8 @@ The inputs to this process are
 
   * variables w and h specifying the width and height of the region to be
     predicted.
-    
-The process combines two predictions according to the mask.  
+
+The process combines two predictions according to the mask.
 It makes use of an array Mask containing the blending weights to apply (the weights are defined for the current plane samples if compound_type is equal to COMPOUND_INTRA, or the luma plane otherwise).
 
 The variables subX and subY describing the subsampling of the current plane
@@ -4065,7 +4065,7 @@ are derived as follows:
 
   * Otherwise (plane is not equal to 0), subX is set equal to subsampling_x
     and subY is set equal to subsampling_y.
-    
+
 The process is specified as follows:
 
 ~~~~~ c
@@ -4193,7 +4193,7 @@ The inputs to this process are:
 
 - variables startX and startY specifying the location of the top left
   sample in the CurrFrame[ plane ] array of the current transform block,
-  
+
 - a variable txSz, specifying the size of the current transform block.
 
 The outputs of this process are modified chroma predicted samples in the current
@@ -4212,7 +4212,7 @@ The variable subY is set equal to subsampling_y.
 The variable alpha depends on the plane as follows:
 
   * If plane is equal to 1, alpha is set equal to CflAlphaU.
-  
+
   * Otherwise (plane is equal to 2), alpha is set equal to CflAlphaV.
 
 An array L (containing subsampled reconstructed luma samples with 3 fractional bits of precision) and lumaAvg (representing the average reconstructed luma intensity with 3 fractional bits of precision) is specified as:
@@ -4226,8 +4226,8 @@ for ( i = 0; i < h; i++ ) {
         lumaX = (startX + j) << subX
         lumaX = Min( lumaX, MaxLumaW - (1 << subX) )
         t = 0
-        for ( dy = 0; dy <= subY; dy += 1 ) 
-            for ( dx = 0; dx <= subX; dx += 1 ) 
+        for ( dy = 0; dy <= subY; dy += 1 )
+            for ( dx = 0; dx <= subX; dx += 1 )
                 t += CurrFrame[ 0 ][ lumaY + dy ]
                                    [ lumaX + dx ]
         v = t << ( 3 - subX - subY )
@@ -4453,7 +4453,7 @@ The function get_qindex( ignoreDeltaQ, segmentId ) returns the quantizer index f
     1. Set the variable data equal to FeatureData[ segmentId ][ SEG_LVL_ALT_Q ].
 
     2. Set qindex equal to base_q_idx + data.
-    
+
     3. If ignoreDeltaQ is equal to 0 and delta_q_present is equal to 1, set qindex equal to CurrentQIndex + data.
 
     4. Return Clip3( 0, 255, qindex ).
@@ -4471,7 +4471,7 @@ The function get_dc_quant( plane ) returns the quantizer value for the dc
 coefficient for a particular plane and is derived as follows:
 
   * If plane is equal to 0, return dc_q( get_qindex( 0, segment_id ) + DeltaQYDc ).
-  
+
   * Otherwise if plane is equal to 1, return dc_q( get_qindex( 0, segment_id ) + DeltaQUDc ).
 
   * Otherwise (plane is equal to 2), return dc_q( get_qindex( 0, segment_id ) + DeltaQVDc ).
@@ -4480,7 +4480,7 @@ The function get_ac_quant( plane ) returns the quantizer value for the ac
 coefficient for a particular plane and is derived as follows:
 
   * If plane is equal to 0, return ac_q( get_qindex( 0, segment_id ) ).
-  
+
   * Otherwise if plane is equal to 1, return ac_q( get_qindex( 0, segment_id ) + DeltaQUAc ).
 
   * Otherwise (plane is equal to 2), return ac_q( get_qindex( 0, segment_id ) + DeltaQVAc ).
@@ -4510,9 +4510,9 @@ The reconstruction and dequantization process is defined as follows:
 The variable dqDenom is derived as follows:
 
   * If txSz is equal to TX_32X32, TX_16X32, TX_32X16, TX_16X64, or TX_64X16, dqDenom is set equal to 2.
-  
+
   * Otherwise, if txSz is equal to TX_64X64, TX_32X64, or TX_64X32, dqDenom is set equal to 4.
-  
+
   * Otherwise, dqDenom is set equal to 1.
 
 The variable log2W (specifying the base 2 logarithm of the width of the transform
@@ -4542,26 +4542,26 @@ flipLR is set equal to 0.
 The following ordered steps apply:
 
   1. For i = 0..(th-1), for j = 0..(tw-1), the following ordered steps apply:
-  
+
       a. The variable q is derived as follows:
-        
+
         * If i is equal to 0 and j is equal to 0, the variable q is set equal to get_dc_quant( plane ).
-      
+
         * Otherwise (i, j or both are not equal to 0), the variable q is set equal to get_ac_quant( plane ).
-      
+
       b. The variable q2 is derived as follows:
-      
+
         * If using_qmatrix is equal to 1, PlaneTxType is less than IDTX, and SegQMLevel[ plane ][ segment_id ] is less than 15, q2 is set
          equal to Round2( q * Quantizer_Matrix[ SegQMLevel[ plane ][ segment_id ] ][ plane > 0 ][ Qm_Offset[ txSz ] + i * tw + j ], 5 ).
-         
+
         * Otherwise, q2 is set equal to q.
 
       c. The variable dq is set equal to Quant[ i * tw + j ] * q2.
-      
+
       d. The variable sign is set equal to ( dq < 0 ) ? -1 : 1.
-      
+
       e. The variable dq2 is set equal to sign * ( Abs( dq ) & 0xFFFFFF ) / dqDenom.
-      
+
       f. Dequant[ i ][ j ] is set equal to Clip3( - ( 1 \<\< ( 7 + BitDepth ) ), ( 1 \<\< ( 7 + BitDepth ) ) - 1, dq2 ).
 
   2. Invoke the 2D inverse transform block process defined in [section 7.13.3][]
@@ -4569,11 +4569,11 @@ The following ordered steps apply:
      in the Residual buffer.
 
   3. For i = 0..(h-1), for j = 0..(w-1), the following applies:
-  
+
       * The variable xx is set equal to flipLR ? ( w - j - 1 ) : j.
-        
+
       * The variable yy is set equal to flipUD ? ( h - i - 1 ) : i.
-      
+
       * CurrFrame[ plane ][ y + yy ][ x + xx ] is set equal to
         Clip1( CurrFrame[ plane ][ y + yy ][ x + xx ] + Residual[ i ][ j ] ).
 
@@ -4735,85 +4735,85 @@ This process performs an in-place inverse discrete cosine transform of the
 permuted array T which is of length 2<sup>n</sup> for 2 ≤ n ≤ 6.
 
 The inputs to this process are:
-  
+
   * a variable n that specifies the base 2 logarithm of the length of the input array,
-    
+
   * a variable r that specifies the intermediate clamping range.
 
 The following ordered steps apply:
 
   1. Invoke the inverse DCT permutation process as specified in [section 7.13.2.2][] with the input variable n.
-  
+
   2. If n is equal to 6, invoke B( 32 + i, 63 - i, 63 - 4 * brev( 4, i ), 0, r ) for i = 0..15.
-  
+
   3. If n is greater than or equal to 5, invoke B( 16 + i, 31 - i, 6 + ( brev( 3, 7 - i ) \<\< 3 ), 0, r )
      for i = 0..7.
-  
+
   4. If n is equal to 6, invoke H( 32 + i * 2, 33 + i * 2, i & 1, r ) for i = 0..15.
-  
+
   5. If n is greater than or equal to 4, invoke B( 8 + i, 15 - i, 12 + ( brev( 2, 3 - i ) \<\< 4 ),
      0, r ) for i = 0..3.
-     
+
   6. If n is greater than or equal to 5, invoke H( 16 + 2 * i, 17 + 2 * i, i & 1, r ) for i = 0..7.
-  
+
   7. If n is equal to 6, invoke B( 62 - i * 4 - j, 33 + i * 4 + j, 60 - 16 * brev( 2, i ) + 64 * j, 1, r )
      for i = 0..3, for j = 0..1.
-     
+
   8. If n is greater than or equal to 3, invoke B( 4 + i, 7 - i, 56 - 32 * i, 0, r )
      for i = 0..1.
-  
+
   9. If n is greater than or equal to 4, invoke H( 8 + 2 * i, 9 + 2 * i, i & 1, r ) for i = 0..3.
-  
+
   10. If n is greater than or equal to 5, invoke B( 30 - 4 * i - j, 17 + 4 * i + j, 24 + (j \<\< 6) + ( ( 1 - i ) \<\< 5 ),
       1, r ) for i = 0..1, for j=0..1.
-  
+
   11. If n is equal to 6, invoke H( 32 + i * 4 + j, 35 + i * 4 - j, i & 1, r ) for i = 0..7, for j = 0..1.
-  
+
   12. Invoke B( 2 * i, 2 * i + 1, 32 + 16 * i, 1 - i, r ) for i = 0..1.
-  
+
   13. If n is greater than or equal to 3, invoke H( 4 + 2 * i, 5 + 2 * i, i, r ) for i = 0..1.
-  
+
   14. If n is greater than or equal to 4, invoke B( 14 - i, 9 + i, 48 + 64 * i, 1, r ) for
      i = 0..1.
-  
+
   15. If n is greater than or equal to 5, invoke H( 16 + 4 * i + j, 19 + 4 * i - j, i & 1, r ) for i = 0..3, for j = 0..1.
-  
+
   16. If n is equal to 6, invoke B( 61 - i * 8 - j, 34 + i * 8 + j, 56 - i * 32 + ( j \>\> 1 ) * 64, 1, r )
       for i = 0..1, for j = 0..3.
-     
+
   17. Invoke H( i, 3 - i, 0, r ) for i = 0..1.
-  
+
   18. If n is greater than or equal to 3, invoke B( 6, 5, 32, 1, r ).
-  
+
   19. If n is greater than or equal to 4, invoke H( 8 + 4 * i + j, 11 + 4 * i - j, i, r ) for i = 0..1,
       for j = 0..1.
-  
+
   20. If n is greater than or equal to 5, invoke B( 29 - i, 18 + i, 48 + ( i \>\> 1 ) * 64, 1, r ) for i = 0..3.
-  
+
   21. If n is equal to 6, invoke H( 32 + 8 * i + j, 39 + 8 * i - j, i & 1, r ) for i = 0..3, for j = 0..3.
-  
+
   22. If n is greater than or equal to 3, invoke H( i, 7 - i, 0, r ) for i = 0..3.
-  
+
   23. If n is greater than or equal to 4, invoke B( 13 - i, 10 + i, 32, 1, r ) for i = 0..1.
-  
+
   24. If n is greater than or equal to 5, invoke H( 16 + i * 8 + j, 23 + i * 8 - j, i, r ) for i = 0..1, for j = 0..3.
-  
+
   25. If n is equal to 6, invoke B( 59 - i, 36 + i, i < 4 ? 48 : 112, 1, r ) for i = 0..7.
-  
+
   26. If n is greater than or equal to 4, invoke H( i, 15 - i, 0, r ) for i = 0..7.
-  
+
   27. If n is greater than or equal to 5, invoke B( 27 - i, 20 + i, 32, 1, r ) for i = 0..3.
-  
+
   28. If n is equal to 6, the following steps apply for i = 0..7:
-      
+
       * Invoke H( 32 + i, 47 - i, 0, r ).
-      
+
       * Invoke H( 48 + i, 63 - i, 1, r ).
-      
+
   29. If n is greater than or equal to 5, invoke H( i, 31 - i, 0, r ) for i = 0..15.
-  
+
   30. If n is equal to 6, invoke B( 55 - i, 40 + i, 32, 1, r ) for i = 0..7.
-  
+
   31. If n is equal to 6, invoke H( i, 63 - i, 0, r ) for i = 0..31.
 
 ##### Inverse ADST input array permutation process
@@ -4829,9 +4829,9 @@ The variable n0 is set equal to 1 \<\< n.
 A temporary array named copyT is set equal to T.
 
 The following steps apply for i = 0..(n0-1):
-  
+
   * The variable idx is set equal to ( i & 1 ) ? ( i - 1 ) : ( n0 - i - 1 ).
-  
+
   * T[ i ] is set equal to copyT[ idx ].
 
 
@@ -4850,15 +4850,15 @@ A temporary array named copyT is set equal to T.
 The following steps apply for i = 0..(n0-1):
 
   * The variable a is set equal to ( ( i \>\> 3 ) & 1 ).
-  
+
   * The variable b is set equal to ( ( i \>\> 2 ) & 1 ) ^ ( ( i \>\> 3 ) & 1 ).
-  
+
   * The variable c is set equal to ( ( i \>\> 1 ) & 1 ) ^ ( ( i \>\> 2 ) & 1 ).
-  
+
   * The variable d is set equal to ( i & 1 ) ^ ( ( i \>\> 1 ) & 1 ).
-  
+
   * The variable idx is set equal to ( ( d \<\< 3 ) \| ( c \<\< 2 ) \| ( b \<\< 1 ) \| a ) \>\> ( 4 - n ).
-  
+
   * T[ i ] is set equal to ( i & 1 ) ? ( - copyT[ idx ] ) : copyT[ idx ].
 
 
@@ -4926,22 +4926,22 @@ are representable by a signed integer using r bits of precision.
 This process performs an in-place inverse ADST process on the array T of size 8.
 
 The input to this process is a variable r, specifying the intermediate clamping range.
-  
+
 The following ordered steps apply:
-  
+
   1. Invoke the ADST input array permutation process specified in [section 7.13.2.4][] with the 
      input variable n set to 3.
-       
+
   2. Invoke B( 2 * i, 2 * i + 1, 60 - 16 * i, 1, r ) for i = 0..3.
-  
+
   3. Invoke H( i, 4 + i, 0, r ) for i = 0..3.
-  
+
   4. Invoke B( 4 + 3 * i, 5 + i, 48 - 32 * i, 1, r ) for i = 0..1.
-  
+
   5. Invoke H( 4 * j + i, 2 + 4 * j + i, 0, r ) for i = 0..1, for j = 0..1.
-  
+
   6. Invoke B( 2 + 4 * i, 3 + 4 * i, 32, 1, r ) for i = 0..1.
-  
+
   7. Invoke the ADST output array permutation process specified in [section 7.13.2.5][] with the 
      input variable n set to 3.
 
@@ -4950,27 +4950,27 @@ The following ordered steps apply:
 This process performs an in-place inverse ADST process on the array T of size 16.
 
 The input to this process is a variable r, specifying the intermediate clamping range.
-  
+
   The following ordered steps apply:
-  
+
   1. Invoke the ADST input array permutation process specified in [section 7.13.2.4][] with the 
      input variable n set to 4.
-     
+
   2. Invoke B( 2 * i, 2 * i + 1, 62 - 8 * i, 1, r ) for i = 0..7.
-     
+
   3. Invoke H( i, 8 + i, 0, r ) for i = 0..7.
-     
+
   4. Invoke B( 8 + 2 * i, 9 + 2 * i, 56 - 32 * i, 1, r ) and B( 13 + 2 * i, 12 + 2 * i, 8 + 32 * i, 1, r )
      for i = 0..1.
-     
+
   5. Invoke H( 8 * j + i, 4 + 8 * j + i, 0, r ) for i = 0..3, for j = 0..1.
-     
+
   6. Invoke B( 4 + 8 * j + 3 * i, 5 + 8 * j + i, 48 - 32 * i, 1, r ) for i = 0..1, for j = 0..1.
-     
+
   7. Invoke H( 4 * j + i, 2 + 4 * j + i, 0, r ) for i = 0..1, for j = 0..3.
-     
+
   8. Invoke B( 2 + 4 * i, 3 + 4 * i, 32, 1, r ) for i = 0..3.
-     
+
   9. Invoke the ADST output array permutation process specified in [section 7.13.2.5][] with the 
      input variable n set to 4.
 
@@ -4981,23 +4981,23 @@ This process performs an in-place inverse ADST process on the array T of size
 2<sup>n</sup> for 2 ≤ n ≤ 4.
 
 The inputs to this process are:
-  
+
   * a variable n that specifies the base 2 logarithm of the length of the input array.
-  
+
   * a variable r that specifies the intermediate clamping range.
 
 The following steps apply:
 
   * If n is equal to 2, invoke the inverse ADST4 process in [section 7.13.2.6][], with the input
     variable r.
-  
+
   * Otherwise, if n is equal to 3, invoke the inverse ADST8 process in [section 7.13.2.7][], with the
     input variable r.
-  
+
   * Otherwise (n is equal to 4), invoke the inverse ADST16 process in [section 7.13.2.8][], with the
     input variable r.
-  
-  
+
+
 ##### Inverse Walsh-Hadamard transform process
 
 The input to this process is a variable shift that specifies the amount of
@@ -5077,13 +5077,13 @@ The process to invoke depends on n as follows:
 
   * If n is equal to 2, invoke the inverse identity transform 4 process in
     [section 7.13.2.11][].
-  
+
   * Otherwise, if n is equal to 3, invoke the inverse identity transform 8 process in
     [section 7.13.2.12][].
-  
+
   * Otherwise, if n is equal to 4, invoke the inverse identity transform 16 process in
     [section 7.13.2.13][].
-  
+
   * Otherwise (n is equal to 5), invoke the inverse identity transform 32 process in
     [section 7.13.2.14][].
 
@@ -5114,7 +5114,7 @@ Set the variable colClampRange equal to Max( BitDepth + 6, 16 ).
 The row transforms with i = 0..(h-1) are applied as follows:
 
   * T[ j ] is derived as follows for j = 0..(w-1):
-  
+
       * If i and j are both less than 32, T[ j ] is set equal to Dequant[ i ][ j ].
 
       * Otherwise, T[ j ] is set equal to 0.
@@ -5133,10 +5133,10 @@ The row transforms with i = 0..(h-1) are applied as follows:
     ADST_FLIPADST, FLIPADST_ADST, H_ADST, or H_FLIPADST, invoke the inverse ADST process as 
     specified in [section 7.13.2.9][] with input variable n equal to log2W and the input variable
     r equal to rowClampRange.
-    
+
   * Otherwise, invoke the inverse identity transform process specified in [section 7.13.2.15][] with the
     input variable n equal to log2W.
-    
+
   * Set Residual[ i ][ j ] equal to Round2( T[ j ], rowShift ) for j = 0..(w-1).
 
 Between the row and column transforms, Residual[ i ][ j ] is set equal to Clip3( - ( 1 \<\< ( colClampRange - 1 ) ),
@@ -5148,21 +5148,21 @@ The column transforms with j = 0..(w-1) are applied as follows:
 
   * If Lossless is equal to 1, invoke the Inverse WHT process as specified in
     [section 7.13.2.10][] with shift equal to 0.
-    
+
   * Otherwise, if PlaneTxType is equal to one of DCT_DCT, DCT_ADST, DCT_FLIPADST or
     V_DCT, invoke the inverse DCT process as specified in [section 7.13.2.3][]
     with the input variable n equal to log2H and the input variable r equal to
     colClampRange.
 
-  * Otherwise, if PlaneTxType is equal to one of ADST_DCT, ADST_ADST, FLIPADST_DCT, 
+  * Otherwise, if PlaneTxType is equal to one of ADST_DCT, ADST_ADST, FLIPADST_DCT,
     FLIPADST_FLIPADST, ADST_FLIPADST, FLIPADST_ADST, V_ADST, or V_FLIPADST,
     invoke the inverse ADST process as specified in [section 7.13.2.9][] with input variable n equal to
     log2H and the input variable r equal to
     colClampRange.
-    
+
   * Otherwise, invoke the inverse identity transform process specified in [section 7.13.2.15][] with the
     input variable n equal to log2H.
-  
+
   * Residual[ i ][ j ] is set equal to Round2( T[ i ], colShift ) for i = 0..(h-1).
 
 where Transform_Row_Shift is defined as:
@@ -5279,17 +5279,17 @@ boundary lie in the visible area) is derived as follows:
     equal to 0.
 
   * Otherwise, onScreen is set equal to 1.
-      
+
 If onScreen is equal to 0, then this process immediately returns and no filtering is applied to this edge.
-       
+
 The variables xP and yP (containing the location in the current plane) are derived as follows:
-  
+
   * Set xP equal to x \>\> subX
 
-  * Set yP equal to y \>\> subY  
-    
+  * Set yP equal to y \>\> subY
+
 The variables prevRow and prevCol (containing the location of the mode info block on the other side of the boundary) are derived as follows:
-  
+
   * Set prevRow equal to row - ( dy \<\< subY )
 
   * Set prevCol equal to col - ( dx \<\< subX )
@@ -5301,10 +5301,10 @@ Set the variable txSz equal to LoopfilterTxSizes[ plane ][ row \>\> subY ][ col 
 Set the variable planeSize equal to get_plane_residual_size( MiSize, plane )
 
 Set the variable skip equal to Skips[ row ][ col ].
-  
+
 Set the variable isIntra equal to
      RefFrames[ row ][ col ][ 0 ] <= INTRA_FRAME.
-  
+
 Set the variable prevTxSz equal to LoopfilterTxSizes[ plane ][ prevRow \>\> subY ][ prevCol \>\> subX ].
 
 The variable isBlockEdge (equal to 1 if the samples cross a prediction
@@ -5323,7 +5323,7 @@ edge) is derived as follows:
 
   * If pass is equal to 0 and xP is an exact multiple of Tx_Width[ txSz ], isTxEdge is set
     equal to 1.
-    
+
   * Otherwise, if pass is equal to 1 and yP is an exact multiple of Tx_Height[ txSz ], isTxEdge is set
     equal to 1.
 
@@ -5347,11 +5347,11 @@ used).
 The adaptive filter strength process specified in [section 7.14.4][] is invoked with
 the inputs row, col, plane, and pass, and the output assigned to the variables
 lvl, limit, blimit, and thresh.
-      
+
 If lvl is equal to 0, the adaptive filter strength process specified in [section 7.14.4][] is invoked with
 the inputs prevRow, prevCol, plane, and pass, and the output assigned to the variables
 lvl, limit, blimit, and thresh.
-      
+
 For the variable i taking values from 0 to MI_SIZE - 1, the following applies:
 
   * If applyFilter is equal to 1 and lvl is greater than zero, the sample
@@ -5370,11 +5370,11 @@ For the variable i taking values from 0 to MI_SIZE - 1, the following applies:
 The inputs to this process are:
 
   * a variable txSz specifying the size of the transform block,
-  
+
   * a variable prevTxSz specifying the size of the transform block on the other side of the boundary,
 
   * a variable pass specifying the direction of the edges,
-  
+
   * a variable plane specifying whether the process is filtering Y, U, or V samples.
 
 The output of this process is the variable filterSize containing the maximum
@@ -5386,7 +5386,7 @@ that different boundaries can be filtered in parallel.
 The variable baseSize is derived as follows:
 
   * If pass is equal to 0, baseSize is set equal to Min( Tx_Width[ prevTxSz ], Tx_Width[ txSz ] ),
-  
+
   * Otherwise (pass is equal to 1), baseSize is set equal to Min( Tx_Height[ prevTxSz ], Tx_Height[ txSz ] ).
 
 The output variable filterSize is derived as follows:
@@ -5429,7 +5429,7 @@ The output variable lvl is derived as follows:
        to 0.
 
   * The variable deltaLF is derived as follows:
-  
+
     1. If delta_lf_multi is equal to 0, deltaLF is set equal to DeltaLFs[ row ][ col ][ 0 ].
 
     2. Otherwise (delta_lf_multi is equal to 1), deltaLF is set equal to
@@ -5463,11 +5463,11 @@ The output variable thresh is set equal to lvl \>\> 4.
 #### Adaptive filter strength selection process
 
 The inputs to this process are:
- 
+
  * The variable segment, specifying the current segment id,
- 
+
  * The variable ref, specifying the reference frame type (INTRA_FRAME, LAST_FRAME, etc.),
- 
+
  * The variable modeType, specifying the loop filter mode type,
 
  * The variable deltaLF, specifying the loop filter delta value,
@@ -5506,12 +5506,12 @@ The following ordered steps apply:
 
      b. If ref is equal to INTRA_FRAME, then lvlSeg is set equal to lvlSeg +
         ( loop_filter_ref_deltas[ INTRA_FRAME ] \<\< nShift ).
-        
+
      c. Otherwise, if ref is not equal to INTRA_FRAME, then lvlSeg is set equal to
         lvlSeg +
         ( loop_filter_ref_deltas[ ref ] \<\< nShift ) +
         ( loop_filter_mode_deltas[ modeType ] \<\< nShift ).
-        
+
      d. lvlSeg is set equal to Clip3(0, MAX_LOOP_FILTER, lvlSeg).
 
   5. Return lvlSeg.
@@ -5623,11 +5623,11 @@ The variable filterLen, representing the number of taps each side of the central
 sample in the filter, is derived as follows:
 
   * If filterSize is equal to 4, filterLen is set equal to 4.
-  
+
   * Otherwise, if plane is not equal to 0, filterLen is set equal to 6.
-  
+
   * Otherwise, if filterSize is equal to 8, filterLen is set equal to 8.
-  
+
   * Otherwise, filterLen is set equal to 16.
 
 The value of filterMask indicates whether adjacent samples close to the
@@ -5779,15 +5779,15 @@ The variable n (specifying the number of filter taps on each side of the
 central sample) is set as follows:
 
   * If log2Size is equal to 4, n is set equal to 6.
-  
+
   * Otherwise if plane is equal to 0, n is set equal to 3.
-  
+
   * Otherwise (log2Size is equal to 3 and plane is greater than 0), n is set equal to 2.
-  
+
 The variable n2 (specifying the number of filter taps equal to 2 on each side of the central sample needed to give a unity DC gain) is set as follows:
 
   * If log2Size is equal to 3 and plane is equal to 0, n2 is set equal to 0.
-  
+
   * Otherwise (log2Size is equal to 4 or plane is greater than 0), n2 is set equal to 1.
 
 This process modifies the samples on each side of the specified boundary by
@@ -5846,9 +5846,9 @@ The inputs to this process are:
 
   *  variables r and c specifying the location of an 8x8 block in units
     of 4x4 blocks in the luma plane,
-    
+
   * a variable idx specifying which set of CDEF parameters to use, or -1 to signal that no filtering should be applied.
-    
+
 The block is first copied to the CdefFrame as follows:
 
 ~~~~~ c
@@ -5889,34 +5889,35 @@ If skip is equal to 0, the CDEF direction process specified in [section 7.15.2][
 
 If skip is equal to 0, the following ordered steps apply:
 
- 1. The variable priStr is set equal to cdef_y_pri_strength[ idx ] \<\< coeffShift.
- 
- 2. The variable secStr is set equal to cdef_y_sec_strength[ idx ] \<\< coeffShift.
- 
- 3. The variable dir is set equal to ( priStr == 0 ) ? 0 : yDir.
- 
- 4. The variable varStr is set equal to ( var \>\> 6 ) ? Min( FloorLog2( var \>\> 6 ), 12) : 0.
- 
- 5. The variable priStr is set equal to ( var ? ( priStr * ( 4 + varStr ) + 8 ) \>\> 4 : 0 ).
- 
- 6. The variable damping is set equal to CdefDamping + coeffShift.
- 
- 7. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 0, r, c, priStr, secStr, damping, and dir as input.
- 
- 8. If NumPlanes is equal to 1, the process terminates at this point (i.e. filtering is not done for the U and V planes).
+  1. The variable priStr is set equal to cdef_y_pri_strength[ idx ] \<\< coeffShift.
 
- 8. The variable priStr is set equal to cdef_uv_pri_strength[ idx ] \<\< coeffShift.
- 
- 9. The variable secStr is set equal to cdef_uv_sec_strength[ idx ] \<\< coeffShift.
- 
- 10. The variable dir is set equal to ( priStr == 0 ) ? 0 : Cdef_Uv_Dir[ subsampling_x ][ subsampling_y ][ yDir ].
- 
- 11. The variable damping is set equal to CdefDamping + coeffShift - 1.
- 
- 12. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 1, r, c, priStr, secStr, damping, and dir as input.
- 
- 13. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 2, r, c, priStr, secStr, damping, and dir as input.
- 
+  2. The variable secStr is set equal to cdef_y_sec_strength[ idx ] \<\< coeffShift.
+
+  3. The variable dir is set equal to ( priStr == 0 ) ? 0 : yDir.
+
+  4. The variable varStr is set equal to ( var \>\> 6 ) ? Min( FloorLog2( var \>\> 6 ), 12) : 0.
+
+  5. The variable priStr is set equal to ( var ? ( priStr * ( 4 + varStr ) + 8 ) \>\> 4 : 0 ).
+
+  6. The variable damping is set equal to CdefDamping + coeffShift.
+
+  7. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 0, r, c, priStr, secStr, damping, and dir as input.
+
+  8. If NumPlanes is equal to 1, the process terminates at this point (i.e. filtering is not done for the U and V planes).
+
+  8. The variable priStr is set equal to cdef_uv_pri_strength[ idx ] \<\< coeffShift.
+
+  9. The variable secStr is set equal to cdef_uv_sec_strength[ idx ] \<\< coeffShift.
+
+  10. The variable dir is set equal to ( priStr == 0 ) ? 0 :
+      Cdef_Uv_Dir[ subsampling_x ][ subsampling_y ][ yDir ].
+
+  11. The variable damping is set equal to CdefDamping + coeffShift - 1.
+
+  12. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 1, r, c, priStr, secStr, damping, and dir as input.
+
+  13. The CDEF filter process specified in [section 7.15.3][] is invoked with plane equal to 2, r, c, priStr, secStr, damping, and dir as input.
+
 Cdef_Uv_Dir is a constant lookup table defined as:
 
 ~~~~~ c
@@ -5936,9 +5937,9 @@ The inputs to this process are variables r and c specifying the location of an 8
 The outputs of this process are:
 
   * a variable yDir containing the direction of this block,
-  
+
   * a variable var containing the variance for this block.
-  
+
 This block uses luma samples to measure the direction and variance of a block.
 
 The process is specified as:
@@ -6005,7 +6006,7 @@ var = (bestCost - cost[(yDir + 4) & 7]) >> 10
 where the Div_Table is a constant lookup table specified as:
 
 ~~~~~ c
-Div_Table[9] = { 
+Div_Table[9] = {
     0, 840, 420, 280, 210, 168, 140, 120, 105
 }
 ~~~~~
@@ -6015,15 +6016,15 @@ Div_Table[9] = {
 The inputs to this process are:
 
   * a variable plane specifying which plane is being predicted,
-  
+
   * variables r and c specifying the location of an 8x8 block in units of 4x4 blocks in the luma plane,
 
   * a variable priStr specifying the primary filter strength,
-  
+
   * a variable secStr specifying the secondary filter strength,
-  
+
   * a variable damping specifying a shift used for damping,
-  
+
   * a variable dir specifying the detected direction of the block.
 
 The process modifies samples in CdefFrame based on filtering samples from CurrFrame.
@@ -6067,7 +6068,7 @@ for ( i = 0; i < h; i++ ) {
                         min = Min(s, min)
                     }
                 }
-            } 
+            }
         }
         CdefFrame[plane][y0 + i][x0 + j] = Clip3(min, max, x + ((8 + sum - (sum < 0)) >> 4) )
     }
@@ -6077,12 +6078,12 @@ for ( i = 0; i < h; i++ ) {
 where Cdef_Pri_Taps and Cdef_Sec_Taps are constant lookup tables specified as:
 
 ~~~~~ c
-Cdef_Pri_Taps[2][2] = { 
-    { 4, 2 }, { 3, 3 } 
+Cdef_Pri_Taps[2][2] = {
+    { 4, 2 }, { 3, 3 }
 }
 
-Cdef_Sec_Taps[2][2] = { 
-    { 2, 1 }, { 2, 1 } 
+Cdef_Sec_Taps[2][2] = {
+    { 2, 1 }, { 2, 1 }
 }
 ~~~~~
 
@@ -6232,7 +6233,7 @@ Output from this process is the array LrFrame of loop restored samples.
 
 **Note:** Although this process loops over 4x4 blocks,
 loop restoration is designed to work in stripes 64 luma samples high without needing additional line buffers.
-Samples within the current stripe are fetched from UpscaledCdefFrame. 
+Samples within the current stripe are fetched from UpscaledCdefFrame.
 Samples outside the current stripe are fetched from UpscaledCurrFrame (these samples will be deblocked, but will not have CDEF filtering applied).
 {:.alert .alert-info }
 
@@ -6267,7 +6268,7 @@ The inputs to this process are:
 
   * variables row and col specifying the location of the block in units
     of 4x4 blocks in the upscaled luma plane.
-    
+
 The output of this process are samples in LrFrame[ plane ].
 
 The variable lumaY is set equal to row * MI_SIZE.
@@ -6285,7 +6286,7 @@ plane as follows:
 
   * Otherwise, subX is set equal to subsampling_x and subY is set equal to
    subsampling_y.
-   
+
 The variable StripeStartY (specifying the start of the stripe in units of samples in the current plane) is set equal to ( (-8 + stripeNum * 64) \>\> subY ).
 
 The variable StripeEndY (specifying the end of the stripe in units of samples in the current plane) is set equal to StripeStartY + (64 \>\> subY) - 1.
@@ -6307,11 +6308,11 @@ The variable unitRow (specifying the vertical index of the current loop restorat
 The variable unitCol (specifying the horizontal index of the current loop restoration unit) is set equal to Min( unitCols - 1, ( col * MI_SIZE \>\> subX ) / unitSize ).
 
 The horizontal extent of the space allowed for filtering is specified as follows:
-     
+
 The variable PlaneEndX (specifying the horizontal extent of the space allowed for filtering) is set equal to Round2( UpscaledWidth, subX ) - 1.
-     
+
 The variable PlaneEndY (specifying the vertical extent of the space allowed for filtering) is set equal to Round2( FrameHeight, subY ) - 1.
-     
+
 The variable x is set equal to ( col * MI_SIZE \>\> subX ).
 
 The variable y is set equal to ( row * MI_SIZE \>\> subY ).
@@ -6326,25 +6327,25 @@ Variables w and h represent the size of the block in samples.)
 **Note:** Although the filter is described as operating on small blocks, the output will be the same
 if larger blocks are used - provided all contained samples belong to the same loop restoration unit.
 {:.alert .alert-info }
-     
+
 The variable rType (specifying the loop restoration type) is set equal to LrType[ plane ][ unitRow ][ unitCol ].
 
 The filter to used depends on rType as follows:
 
   * If rType is equal to RESTORE_WIENER, the Wiener filter process specified in [section 7.17.4][] is invoked with plane, unitRow, unitCol, x, y, w, and h as inputs.
-  
+
   * Otherwise, if rType is equal to RESTORE_SGRPROJ, the self guided filter process specified in [section 7.17.2][] is invoked with plane, unitRow, unitCol, x, y, w, and h as inputs.
-  
+
   * Otherwise (rType is equal to RESTORE_NONE), no filtering is applied.
-  
+
 #### Self guided filter process
 
 The inputs to this block are:
 
   * a variable plane specifying whether the process is filtering Y, U, or V samples,
-  
+
   * variables unitRow and unitCol specifying the position of the loop restoration unit,
-  
+
   * variables x and y specifying the position of the block in samples relative to the top-left corner of the current plane,
 
   * variables w and h specifying the size of the block in samples.
@@ -6352,15 +6353,15 @@ The inputs to this block are:
 The arrays flt0 and flt1 are prepared by the following ordered steps:
 
   1. The variable set is set equal to LrSgrSet[ plane ][ unitRow ][ unitCol ].
-  
+
   2. The variable pass is set equal to 0.
-  
+
   3. The box filter process specified in [section 7.17.3][] is invoked with plane, x, y, w, h, set, and pass as inputs, and the output assigned to flt0.
-  
+
   4. The variable pass is set equal to 1.
-  
+
   5. The box filter process specified in [section 7.17.3][] is invoked with plane, x, y, w, h, set, and pass as inputs, and the output assigned to flt1.
-  
+
 The restoration process is then applied for each sample as follows:
 
 ~~~~~ c
@@ -6392,15 +6393,15 @@ for ( i = 0; i < h; i++ ) {
 The inputs to this process are:
 
   * a variable plane specifying whether the process is filtering Y, U, or V samples,
-  
+
   * variables x and y specifying the position of the block in samples relative to the top-left corner of the current plane,
 
   * variables w and h specifying the size of the block in samples,
-  
+
   * a variable set specifying the strength of the filtering,
-  
+
   * a variable pass (equal to 0 or 1), specifying if the process is generating the first or second filtered output.
-  
+
 The output of this process is a 2d array F.
 
 The variable r (specifying that the box filters have side length 2*r+1) is set equal to Sgr_Params[ set ][ pass * 2 + 0 ].
@@ -6444,7 +6445,7 @@ for ( i = -1; i < h + 1; i++ ) {
 }
 ~~~~~
 
-**Note:** When pass is equal to 0, only odd rows (i.e. entries A[ i ][ j ] and B[ i ][ j ] with i odd) will be used to generate the output.  
+**Note:** When pass is equal to 0, only odd rows (i.e. entries A[ i ][ j ] and B[ i ][ j ] with i odd) will be used to generate the output.
 {:.alert .alert-info }
 
 where the call to get_source_sample specifies that the get source sample process specified in [section 7.17.6][] should be invoked
@@ -6478,7 +6479,7 @@ for ( i = 0; i < h; i++ ) {
         }
         v = a * UpscaledCdefFrame[ plane ][ y + i ][ x + j ] + b
         F[ i ][ j ] = Round2( v, SGRPROJ_SGR_BITS + shift - SGRPROJ_RST_BITS)
-    }   
+    }
 }
 ~~~~~
 
@@ -6502,13 +6503,13 @@ Sgr_Params[ (1 << SGRPROJ_PARAMS_BITS) ][ 4 ] = {
 The inputs to this block are:
 
   * a variable plane specifying whether the process is filtering Y, U, or V samples,
-  
+
   * variables unitRow and unitCol specifying the position of the loop restoration unit,
-  
+
   * variables x and y specifying the position of the block in samples relative to the top-left corner of the current plane,
 
   * variables w and h specifying the size of the block in samples.
-  
+
 The output from this process are modified samples in LrFrame.
 
 The sub-sample interpolation is effected via two one-dimensional convolutions.
@@ -6521,7 +6522,7 @@ The Wiener coefficient process specified in [section 7.17.5][] is invoked with a
 
 The Wiener coefficient process specified in [section 7.17.5][] is invoked with an input of LrWiener[ plane ][ unitRow ][ unitCol ][ 1 ] and the output assigned to hfilter.
 
-**Note:** The horizontal filter needs to be applied before the vertical filter, but the horizontal coefficients are sent after the vertical coefficients. 
+**Note:** The horizontal filter needs to be applied before the vertical filter, but the horizontal coefficients are sent after the vertical coefficients.
 {:.alert .alert-info }
 
 The filtering is applied as follows:
@@ -6541,15 +6542,15 @@ The filtering is applied as follows:
         }
     }
     ~~~~~
-    
+
     Where the call to get_source_sample specifies that the get source sample process specified in [section 7.17.6][] should be invoked.
-    
+
     **Note:** The intermediate result is clipped so that ( intermediate[ r ][ c ] + offset ) fits in an unsigned variable with Min(15,BitDepth + 5) bits.
     {:.alert .alert-info }
-    
+
   * The output samples are written as follows:
 
-    ~~~~~ c 
+    ~~~~~ c
     for ( r = 0; r < h; r++ ) {
         for ( c = 0; c < w; c++ ) {
             s = 0
@@ -6560,7 +6561,7 @@ The filtering is applied as follows:
         }
     }
     ~~~~~
-    
+
 #### Wiener coefficient process
 
 The input to this process is an array coeff containing 3 coefficients.
@@ -6594,12 +6595,12 @@ The inputs to this process are:
   * a variable plane specifying whether the process is filtering Y, U, or V samples,
 
   * variables x and y specifying the location in the current plane in units of samples.
-  
+
 This process makes sure samples are taken from within the allowed extent for loop restoration filtering.
 
 Samples within the current stripe are taken after Cdef filtering has been applied, samples outside the current stripe
 are taken before Cdef filtering.
-  
+
 The sample to return is specified as follows:
 
 ~~~~~ c
@@ -6658,7 +6659,7 @@ For example, a real implementation might use these arrays to display the frame t
 
 #### Intermediate output preparation process
 
-The output of this process are the variables w, h, subX, and subY describing the format of the data in arrays OutY, OutU, 
+The output of this process are the variables w, h, subX, and subY describing the format of the data in arrays OutY, OutU,
 and OutV.
 
 If show_existing_frame is equal to 1, then the decoder should copy OutY, OutU, and OutV from a previously decoded frame as follows:
@@ -6685,11 +6686,11 @@ If show_existing_frame is equal to 1, then the decoder should copy OutY, OutU, a
     samples down and the sample at location x samples across and y samples
     down is given by OutV[ y ][ x ] = FrameStore[ frame_to_show_map_idx ][ 2 ][ x ][ y ]
     with x = 0..((w + subX) \>\> subX) - 1 and y = 0..((h + subY) \>\> subY) - 1.
-    
+
   * The variable BitDepth is set equal to RefBitDepth[ frame_to_show_map_idx ].
 
   * The bit depth for each sample is BitDepth.
-    
+
 Otherwise (show_existing_frame is equal to 0), then the decoder should copy the
 current frame as follows:
 
@@ -6726,25 +6727,25 @@ The output of this process are the variables w, h, subX, and subY.
 The inputs to this process are:
 
   * variables w and h specifying the width and height of the frame,
-  
+
   * variables subX and subY specifying the subsampling parameters of the frame.
 
 The process modifies the arrays OutY, OutU, OutV to add film grain noise as follows:
 
   1. The variable RandomRegister (used for generating pseudo-random numbers) is set equal to grain_seed.
-  
+
   2. The variable GrainCenter is set equal to 128 \<\< (BitDepth - 8).
-  
+
   3. The variable GrainMin is set equal to = -GrainCenter.
-  
+
   4. The variable GrainMax is set equal to (256 \<\< (BitDepth - 8)) - 1 - GrainCenter.
-  
+
   5. The generate grain process specified in [section 7.18.3.3][] is invoked.
-  
+
   6. The scaling lookup initialization process specified in [section 7.18.3.4][] is invoked.
-  
+
   7. The add noise process specified in [section 7.18.3.5][] is invoked with w, h, subX, and subY as inputs.
-  
+
 ##### Random number process
 
 The input to this process is a variable bits specifying the number of random bits to return.
@@ -6953,9 +6954,9 @@ get_y( plane, i ) {
 The inputs to this process are:
 
   * variables w and h specifying the width and height of the frame,
-  
+
   * variables subX and subY specifying the subsampling parameters of the frame.
-  
+
 This process combines the film grain with the image data.
 
 First an array of noise data noiseStripe is generated for each 32 luma sample high stripe of the image.
@@ -7094,7 +7095,7 @@ for ( y = 0; y < ( (h + subY) >> subY) ; y++ ) {
       noise = Round2( scale_lut( 1, merged ) * noise, ScalingShift )
       OutU[ y ][ x ] = Clip3( minValue, maxChroma, orig + noise )
     }
-    
+
     if ( num_cr_points > 0 || chroma_scaling_from_luma) {
       orig = OutV[ y ][ x ]
       if ( chroma_scaling_from_luma ) {
@@ -7146,7 +7147,7 @@ This process applies some filtering and reordering to the motion vectors to prep
 for storage as part of the reference frame update process.
 
 The following applies for row = 0..MiRows-1, for col = 0..MiCols-1:
-  
+
 ~~~~~ c
     MfRefFrames[ row ][ col ] = NONE
     MfMvs[ row ][ col ][ 0 ] = 0
@@ -7188,17 +7189,17 @@ if bit i of refresh_frame_flags is equal to 1 (i.e.
 if (refresh_frame_flags \>\> i) & 1 is equal to 1):
 
   * RefValid[ i ] is set equal to 1.
-  
+
   * RefFrameId[ i ] is set equal to current_frame_id.
-  
+
   * RefUpscaledWidth[ i ] is set equal to UpscaledWidth.
-  
+
   * RefFrameWidth[ i ] is set equal to FrameWidth.
 
   * RefFrameHeight[ i ] is set equal to FrameHeight.
-  
+
   * RefRenderWidth[ i ] is set equal to RenderWidth.
-  
+
   * RefRenderHeight[ i ] is set equal to RenderHeight.
 
   * RefMiCols[ i ] is set equal to MiCols.
@@ -7225,37 +7226,37 @@ if (refresh_frame_flags \>\> i) & 1 is equal to 1):
 
   * SavedRefFrames[ i ][ row ][ col ] is set equal to MfRefFrames[ row ][ col ] for row =
     0..MiRows-1, for col = 0..MiCols-1.
-    
+
   * SavedMvs[ i ][ row ][ col ][ comp ] is set equal to MfMvs[ row ][ col ][ comp ] for
     comp = 0..1, for row = 0..MiRows-1, for col = 0..MiCols-1.
-  
+
   * SavedGmParams[ i ][ ref ][ j ] is set equal to gm_params[ ref ][ j ]
     for ref = LAST_FRAME..ALTREF_FRAME,
     for j = 0..5.
-    
+
   * SavedSegmentIds[ i ][ row ][ col ] is set equal to
     SegmentIds[ row ][ col ] for row = 0..MiRows-1,
     for col = 0..MiCols-1.
-    
+
   * The function save_cdfs( i ) is invoked (see below).
-  
+
   * If film_grain_params_present is equal to 1, the function save_grain_params( i ) is invoked (see below).
-  
+
   * The function save_loop_filter_params( i ) is invoked (see below).
-  
+
   * The function save_segmentation_params( i ) is invoked (see below).
-  
+
 For each value of i from 0 to NUM_REF_FRAMES - 1, the following applies
 if bit i of refresh_frame_flags is equal to 1 (i.e.
 if (refresh_frame_flags \>\> i) & 1 is equal to 1):
 
   * RefOrderHint[ i ] is set equal to OrderHint.
-    
+
 save_cdfs( ctx ) is a function call that indicates that all the CDF arrays are saved into frame context number ctx in the range 0 to (NUM_REF_FRAMES - 1).
 When this function is invoked the following takes place:
 
   * A copy of each CDF array mentioned in the semantics for init_coeff_cdfs and init_non_coeff_cdfs is saved in an area of memory indexed by ctx.
-  
+
 save_grain_params( i ) is a function call that indicates that all the syntax elements that can be
 read in film_grain_params should be saved into an area of memory indexed by i.
 
@@ -7282,9 +7283,9 @@ frame back into the current frame variables. The index of the saved reference fr
   * FrameWidth is set equal to RefFrameWidth[ frame_to_show_map_idx ].
 
   * FrameHeight is set equal to RefFrameHeight[ frame_to_show_map_idx ].
-  
+
   * RenderWidth is set equal to RefRenderWidth[ frame_to_show_map_idx ].
-  
+
   * RenderHeight is set equal to RefRenderHeight[ frame_to_show_map_idx ].
 
   * MiCols is set equal to RefMiCols[ frame_to_show_map_idx ].
@@ -7298,7 +7299,7 @@ frame back into the current frame variables. The index of the saved reference fr
   * BitDepth is set equal to RefBitDepth[ frame_to_show_map_idx ].
 
   * OrderHint is set equal to RefOrderHint[ frame_to_show_map_idx ].
-  
+
   * OrderHints[ j + LAST_FRAME ] is set equal to SavedOrderHints[ frame_to_show_map_idx ][ j + LAST_FRAME ] for j = 0..REFS_PER_FRAME-1.
 
   * LrFrame[ 0 ][ y ][ x ] is set equal to FrameStore[ frame_to_show_map_idx ][ 0 ][ y ][ x ]
@@ -7311,24 +7312,24 @@ frame back into the current frame variables. The index of the saved reference fr
 
   * MfRefFrames[ row ][ col ] is set equal to SavedRefFrames[ frame_to_show_map_idx ][ row ][ col ]
     for row = 0..MiRows-1, for col = 0..MiCols-1.
-    
+
   * MfMvs[ row ][ col ][ comp ] is set equal to SavedMvs[ frame_to_show_map_idx ][ row ][ col ][ comp ]
     for comp = 0..1, for row = 0..MiRows-1, for col = 0..MiCols-1.
 
   * gm_params[ ref ][ j ] is set equal to SavedGmParams[ frame_to_show_map_idx ][ ref ][ j ]
     for ref = LAST_FRAME..ALTREF_FRAME,
     for j = 0..5.
-    
+
   * SegmentIds[ row ][ col ] is set equal to SavedSegmentIds[ frame_to_show_map_idx ][ row ][ col ]
     for row = 0..MiRows-1,
     for col = 0..MiCols-1.
-    
+
   * The function load_cdfs( frame_to_show_map_idx ) is invoked.
-  
+
   * If film_grain_params_present is equal to 1, the function load_grain_params( frame_to_show_map_idx ) is invoked (see [section 6.8.20][]).
 
   * The function load_loop_filter_params( frame_to_show_map_idx ) is invoked (see below).
-  
+
   * The function load_segmentation_params( frame_to_show_map_idx ) is invoked (see below).
 
 load_loop_filter_params( i ) is a function call that indicates that the values of


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.