### PR TITLE
Remove stray leading and trailing spaces in 09 parsing process

### DIFF
--- a/09.parsing.process.md
+++ b/09.parsing.process.md
@@ -98,9 +98,9 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileTx16x16Cdf
 
   * TileTx32x32Cdf
-  
+
   * TileTx64x64Cdf
-  
+
   * TileTxfmSplitCdf
 
   * TileFilterIntraModeCdf
@@ -126,7 +126,7 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileCompModeCdf
 
   * TileSkipModeCdf
-  
+
   * TileSkipCdf
 
   * TileCompRefCdf
@@ -138,7 +138,7 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileMvJointCdf
 
   * TileMvSignCdf
-  
+
   * TileMvClassCdf
 
   * TileMvClass0BitCdf
@@ -148,7 +148,7 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileMvClass0FrCdf
 
   * TileMvClass0HpCdf
-  
+
   * TileMvBitCdf
 
   * TileMvHpCdf
@@ -192,7 +192,7 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileDeltaQCdf
 
   * TileDeltaLFCdf
-  
+
   * TileDeltaLFMultiCdf[ i ] for i = 0..FRAME_LF_COUNT-1
 
   * TileIntraTxTypeSet1Cdf
@@ -218,47 +218,47 @@ prefixed with "Tile".  This copying produces the following arrays:
   * TileWedgeInterIntraCdf
 
   * TileCompGroupIdxCdf
-  
+
   * TileCompoundIdxCdf
-  
+
   * TileCompoundTypeCdf
 
   * TileInterIntraModeCdf
-  
+
   * TileWedgeIndexCdf
 
   * TileCflAlphaCdf
-  
+
   * TileUseWienerCdf
-  
+
   * TileUseSgrprojCdf
-  
+
   * TileRestorationTypeCdf
-  
+
   * TileTxbSkipCdf
-  
+
   * TileEobPt16Cdf
-  
+
   * TileEobPt32Cdf
-  
+
   * TileEobPt64Cdf
-  
+
   * TileEobPt128Cdf
-  
+
   * TileEobPt256Cdf
-  
+
   * TileEobPt512Cdf
-  
+
   * TileEobPt1024Cdf
-  
+
   * TileEobExtraCdf
-  
+
   * TileDcSignCdf
-  
+
   * TileCoeffBaseEobCdf
-  
+
   * TileCoeffBaseCdf
-  
+
   * TileCoeffBrCdf
 
 #### Boolean decoding process
@@ -313,7 +313,7 @@ It is a requirement of bitstream conformance that the bit at position x is equal
 
 If disable_frame_end_update_cdf is equal to 0 and TileNum is equal to context_update_tile_id,
 a copy is made of the final CDF values for each of the
-CDF arrays mentioned in the semantics for init_coeff_cdfs and init_non_coeff_cdfs. 
+CDF arrays mentioned in the semantics for init_coeff_cdfs and init_non_coeff_cdfs.
 The name of the destination for the copy is the name of the CDF array
 prefixed with "Saved".  The name of the source for the copy is the name of the CDF array
 prefixed with "Tile".
@@ -378,12 +378,12 @@ The range and value are renormalized by the following ordered steps:
      This represents the number of new bits to be added to SymbolValue.
 
   2. The variable SymbolRange is set to SymbolRange \<\< bits.
-  
+
   3. The variable numBits is set equal to Min( bits, Max(0, SymbolMaxBits) ).
      This represents the number of new bits to read from the bitstream.
 
   4. The variable newData is read using the f(numBits) parsing process.
-  
+
   5. The variable paddedData is set equal to newData \<\< ( bits - numBits ).
 
   6. The variable SymbolValue is set to
@@ -593,13 +593,13 @@ process for txfm_split.
 The cdf to return is given by:
 
   * TileTx64x64Cdf[ ctx ] if maxTxDepth is equal to 4.
-  
+
   * TileTx32x32Cdf[ ctx ] if maxTxDepth is equal to 3.
 
   * TileTx16x16Cdf[ ctx ] if maxTxDepth is equal to 2.
 
   * TileTx8x8Cdf[ ctx ] otherwise.
-  
+
 **txfm_split**: the cdf is given by TileTxfmSplitCdf[ ctx ], where ctx is computed by:
 
 ~~~~~ c
@@ -967,7 +967,7 @@ if ( plane == 0 ) {
     } else {
         ctx = 6
     }
-} else { 
+} else {
     above = 0
     left = 0
     for ( i = 0; i < w4; i++ ) {
@@ -984,7 +984,7 @@ if ( plane == 0 ) {
     }
     ctx = ( above != 0 ) + ( left != 0 )
     ctx += 7
-    if ( bw * bh > w * h ) 
+    if ( bw * bh > w * h )
         ctx += 3
 }
 ~~~~~
@@ -1043,7 +1043,7 @@ get_coeff_base_ctx( txSz, plane, blockX, blockY, pos, c, isEob ) {
     row = pos >> bwl
     col = pos - (row << bwl)
     mag = 0
-  
+
     for ( idx = 0; idx < SIG_REF_DIFF_OFFSET_NUM; idx++ ) {
         refRow = row + Sig_Ref_Diff_Offset[ txClass ][ idx ][ 0 ]
         refCol = col + Sig_Ref_Diff_Offset[ txClass ][ idx ][ 1 ]
@@ -1412,7 +1412,7 @@ ctx = Palette_Color_Context[ ColorContextHash ]
 **delta_lf_abs**: the cdf is derived as follows:
 
   * If delta_lf_multi is equal to 0, the cdf is given by TileDeltaLFCdf.
-  
+
   * Otherwise (delta_lf_multi is equal to 1), the cdf is given by TileDeltaLFMultiCdf[ i ].
 
 **intra_tx_type**: the cdf depends on the variable set, as follows:
@@ -1426,7 +1426,7 @@ ctx = Palette_Color_Context[ ColorContextHash ]
 where the variable intraDir is derived as follows:
 
   * If use_filter_intra is equal to 1, intraDir is set equal to Filter_Intra_Mode_To_Intra_Dir[ filter_intra_mode ],
-  
+
   * Otherwise (use_filter_intra is equal to 0), intraDir is set equal to YMode.
 
 The table Filter_Intra_Mode_To_Intra_Dir is defined as:
@@ -1640,4 +1640,3 @@ ctx = (signV - 1) * 3 + signU
 **use_sgrproj**: The cdf is given by TileUseSgrprojCdf.
 
 **restoration_type**: The cdf is given by TileRestorationTypeCdf.
-  


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.