### PR TITLE
Remove stray leading and trailing spaces in 10 additional tables

### DIFF
--- a/10.additional.tables.md
+++ b/10.additional.tables.md
@@ -8,7 +8,7 @@ the Specification.
 ### Scan tables
 
 This section defines the scan order for different types of transform. Each table is named in the form \<type\>\_Scan\_\<w\>x\<h\>, and contains an ordered
-list of positions within a rectangle of width w and height h. Each position is calculated as w * y + x. 
+list of positions within a rectangle of width w and height h. Each position is calculated as w * y + x.
 
 The following table lists pairs of scan tables which are transposes of each other. A table T_wxh is a
 transpose of another table T_hxw if the following function returns 1:
@@ -623,7 +623,7 @@ Block_Height[ x ] is defined to be equal to 4 * Num_4x4_Blocks_High[ x ].
 Size_Group is used to map a block size into a context for intra syntax elements.
 
 ~~~~~ c
-Size_Group[ BLOCK_SIZES ] = { 
+Size_Group[ BLOCK_SIZES ] = {
   0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3,
   3, 3, 3, 3, 3, 0, 0, 1, 1, 2, 2
 }
@@ -661,7 +661,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X128,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
@@ -670,7 +670,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
@@ -679,7 +679,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X4,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X8,
@@ -688,7 +688,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X64,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
@@ -697,7 +697,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X8,
@@ -706,7 +706,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_128X64,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
@@ -715,7 +715,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X16,
@@ -724,7 +724,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_64X128,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_16X4,
@@ -733,7 +733,7 @@ Partition_Subsize[ 10 ][ BLOCK_SIZES ] = {
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID
-  }, {  
+  }, {
                                   BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X16,
@@ -975,7 +975,7 @@ Tx_Height_Log2[ TX_SIZES_ALL ] = {
 ~~~~~
 
 ~~~~~ c
-Wedge_Bits[ BLOCK_SIZES ] = { 
+Wedge_Bits[ BLOCK_SIZES ] = {
   0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 0,
   0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0
  }
@@ -5585,28 +5585,28 @@ The output is an array derivedMatrix of size Tx_Width[ txSz ] * Tx_Height[ txSz 
 matrix.
 
   * The array fundamentalMatrix is derived as follows.
-  
+
       * If Tx_Width[ txSz ] is equal to Tx_Height[ txSz ], fundamentalMatrix is set equal to the 32x32
         fundamental matrix for the quantizer level and plane type in question.
-        
+
       * If Tx_Width[ txSz ] is greater than Tx_Height[ txSz ], fundamentalMatrix is set equal to the 32x16
         fundamental matrix for the quantizer level and plane type in question.
-        
+
       * Otherwise (Tx_Width[ txSz ] is less than Tx_Height[ txSz ]), fundamentalMatrix is set equal to the
         16x32 fundamental matrix for the quantizer level and plane type in question.
-  
+
   * The variable fW is set equal to the width of fundamentalMatrix.
-  
+
   * The variable fH is set equal to the height of fundamentalMatrix.
-  
+
   * The variable ratioW is set equal to fW / Tx_Width[ txSz ].
-  
+
   * The variable ratioH is set equal to fH / Tx_Height[ txSz ].
-  
+
   * The variable phaseW is set equal to ( ratioW + 1 ) / 2 - 1.
-  
+
   * The variable phaseH is set equal to ( ratioH + 1 ) / 2 - 1.
-  
+
   * The array element derivedMatrix[ i * Tx_Width[ txSz ] + j ] is set equal to fundamentalMatrix[ ( ratioH *
     i + phaseH ) * fW + ratioW * j + phaseW ] for i=0..Tx_Height[ txSz ] - 1, for j=0..Tx_Width[ txSz ] - 1.
 


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.