### PR TITLE
Remove stray leading and trailing spaces in 06 bitstream syntax

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -37,7 +37,7 @@ Other methods of packing OBUs into a bitstream format are also allowed.
 |         inTemporalLayer = (OperatingPointIdc \>\> temporal_id ) & 1
 |         inSpatialLayer = (OperatingPointIdc \>\> ( spatial_id + 8 ) ) & 1
 |         if ( !inTemporalLayer \|\| ! inSpatialLayer ) {
-|             drop_obu( )                                 
+|             drop_obu( )
 |             return
 |         }
 |     }
@@ -451,7 +451,7 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |     if ( itu_t_t35_country_code == 0xFF ) {
 |         @@itu_t_t35_country_code_extension_byte           | f(8)
 |     }
-|     @@itu_t_t35_payload_bytes                             
+|     @@itu_t_t35_payload_bytes
 | }
 {:.syntax }
 
@@ -602,7 +602,7 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |         idLen = ( additional_frame_id_length_minus_1 +
 |                   delta_frame_id_length_minus_2 + 3 )
 |     }
-|     allFrames = (1 \<\< NUM_REF_FRAMES) - 1     
+|     allFrames = (1 \<\< NUM_REF_FRAMES) - 1
 |     if ( reduced_still_picture_header ) {
 |         show_existing_frame = 0
 |         frame_type = KEY_FRAME
@@ -641,7 +641,7 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |         } else {
 |             @@showable_frame                                  | f(1)
 |         }
-|         if ( frame_type == SWITCH_FRAME \|\| 
+|         if ( frame_type == SWITCH_FRAME \|\|
 |              ( frame_type == KEY_FRAME && show_frame ) )
 |             error_resilient_mode = 1
 |         else
@@ -1506,7 +1506,7 @@ Remap_Lr_Type[4] = {
 |     for ( ref = LAST_FRAME; ref <= ALTREF_FRAME; ref++ ) {
 |         GmType[ ref ] = IDENTITY
 |         for ( i = 0; i < 6; i++ ) {
-|             gm_params[ ref ][ i ] = ( ( i % 3 == 2 ) ? 
+|             gm_params[ ref ][ i ] = ( ( i % 3 == 2 ) ?
 |                       1 \<\< WARPEDMODEL_PREC_BITS : 0 )
 |         }
 |     }
@@ -1654,7 +1654,7 @@ in the range 0 to mx - 1 (inclusive).
 
 | --------------------------------------------------------- | ---------------- |
 | film_grain_params( ) {                                    | **Type**
-|     if ( !film_grain_params_present \|\| 
+|     if ( !film_grain_params_present \|\|
 |          (!show_frame && !showable_frame) ) {
 |         reset_grain_params()
 |         return
@@ -1867,7 +1867,7 @@ Sgrproj_Xqd_Mid[2] = { -32,  31 }
 |         subY = (plane > 0) ? subsampling_y : 0
 |         sbWidth4 = ( MiColEnd - c ) \>\> subX
 |         sbHeight4 = ( MiRowEnd - r ) \>\> subY
-|         for ( y = -1; y <\= ( sbSize4 \>\> subY ); y++ ) 
+|         for ( y = -1; y <\= ( sbSize4 \>\> subY ); y++ )
 |             for ( x = -1; x <\= ( sbSize4 \>\> subX ); x++ ) {
 |                 if ( y < 0 && x < sbWidth4 )
 |                     BlockDecoded[ plane ][ y ][ x ] = 1
@@ -3198,7 +3198,7 @@ is_scaled( refFrame ) {
 |                 predict_chroma_from_luma( plane, startX, startY, txSz )
 |             }
 |         }
-|         
+|
 |         if ( plane == 0 ) {
 |             MaxLumaW = startX + stepX * 4
 |             MaxLumaH = startY + stepY * 4


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.