### PR TITLE
Remove stray leading and trailing spaces in annex c

### DIFF
--- a/annex.c.experiments.md
+++ b/annex.c.experiments.md
@@ -1,4 +1,4 @@
-## Annex C: Error resilience behavior (informative) 
+## Annex C: Error resilience behavior (informative)
 {:.no_count}
 
 ### General
@@ -28,9 +28,9 @@ that everything other than the sample values can be decoded correctly.
 In particular, a frame that is processable will have correct values for:
 
   * All syntax elements
-  
+
   * The size, bitdepth, subsampling structure of any output frames
-  
+
   * All values written in the reference frame update process specified in [section 7.20][], except for the contents of FrameStore
   (which may or may not be correct).
 
@@ -42,23 +42,23 @@ Formally, the property of being processable is defined as follows.
 A frame with show_existing_frame equal to 0 is defined to be processable if the following conditions are met:
 
   * Either primary_ref_frame is equal to PRIMARY_REF_NONE or ref_frame_idx[ primary_ref_frame ] indicates a frame that has been processed
-  
+
   * Either use_ref_frame_mvs is equal to 0, or ref_frame_idx[ i ] indicates a frame that has been processed for all i = 0..REFS_PER_FRAME-1
-  
+
   * Either allow_warped_motion is equal to 0, or ref_frame_idx[ i ] indicates a frame that has been processed for all i = 0..REFS_PER_FRAME-1
   (this is necessary because the motion_mode syntax parsing depends on whether the reference frame
   has been scaled - but this is not known unless the frame has been processed)
-  
+
   * The decoding process for the frame does not use values in RefOrderHint before they have been written
     (written either by the decoding process for the current frame, or written when a previous frame was processed)
-    
+
   * If the syntax element found_ref is equal to 1, ref_frame_idx[ i ] indicates a frame that has been processed
   (this is necessary because the frame dimensions are only correct for processed frames)
-  
+
 A frame with show_existing_frame equal to 1 is processable if the following condition is met:
 
   * frame_to_show_map_idx indicates a frame that has been processed
-  
+
 (A frame being "processed" means that the frame was processable and has been decoded.)
 
 ### Recommendation for processable frames
@@ -80,26 +80,29 @@ that the resulting bitstream is processable.
 There are some features of the bitstream specification that make this easier to achieve:
 
   * primary_ref_frame, use_ref_frame_mvs, and allow_warped_motion can be controlled at a frame level to satisfy the corresponding conditions
-  
+
   * setting error_resilient_mode equal to 1 causes the order hints to be transmitted if necessary
-  
+
   * found_ref can be cleared to allow the frame resolution to be sent explicitly
-  
+
 ### Decoder consequences of processable frames
 
-For the decoding process to handle this mode of operation, the following modifications should be used: 
+For the decoding process to handle this mode of operation, the following modifications should be used:
 
   * RefValid[ i ] should be set equal to 0 for i = 0..NUM_REF_FRAMES-1 before the decoding process begins
-  
+
   * If frame_id_numbers_present_flag is equal to 1, for the first frame current_frame_id should not be
   compared to PrevFrameID (because PrevFrameID is uninitialized).
-  
+
   * When the syntax element ref_order_hint[ i ] is read, RefOrderHint[ i ] is set equal to ref_order_hint[ i ].
-  
-  * The requirement for bitstream conformance described in the semantics for ref_frame_idx[ i ] (that uses RefValid to check that the reference frames are available) should be ignored
-  
-  * When using the inter prediction process, if RefValid[ refIdx ] is equal to 0, then 
-    the motion vector scaling and block inter prediction processes are not followed. 
+
+  * The requirement for bitstream conformance described in the semantics for
+    ref_frame_idx[ i ]
+    (that uses RefValid to check that the reference frames are available)
+    should be ignored
+
+  * When using the inter prediction process, if RefValid[ refIdx ] is equal to 0, then
+    the motion vector scaling and block inter prediction processes are not followed.
     Instead, preds[ refList ] should be generated using an alternative approach.
     For conformance testing, it may help to define the predicted samples in a standard way.
     The suggested approach is to fill preds[ refList ]


### PR DESCRIPTION
These spaces can be significant to a Markdown transformer.