### PR TITLE
[Editorial] Add missing array index to explanation

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1520,7 +1520,7 @@ reference. It is a requirement of bitstream conformance that whenever
 expectedFrameId[ i ] is calculated, the value matches
 RefFrameId[ ref_frame_idx[ i ] ]
 (this contains the value of current_frame_id at the time that the frame indexed
-by ref_frame_idx was stored).
+by ref_frame_idx[ i ] was stored).
 
 **allow_high_precision_mv** equal to 0 specifies that motion vectors are
 specified to quarter pel precision; allow_high_precision_mv equal to 1


### PR DESCRIPTION
Add an array index ( [ i ] ) to ref_frame_idx.