### PR TITLE
Update 07.bitstream.semantics.md

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -250,9 +250,9 @@ obu_extension_flag is equal to 0 for all OBUs that follow this sequence header u
 but allow decoders to spot when frames have been missed and take an appropriate action.
 {:.alert .alert-info }
 
-**additional_frame_id_length_minus_1** is used to calculate the number of bits used to encode the frame_id syntax element.
+**additional_frame_id_length_minus_1** is used to calculate the number of bits used to encode the display_frame_id or current_frame_id syntax element.
 
-**delta_frame_id_length_minus_2** specifies the number of bits minus 2 used to encode delta_frame_id syntax elements.
+**delta_frame_id_length_minus_2** specifies the number of bits minus 2 used to encode delta_frame_id_minus_1 syntax elements.
 
 **use_128x128_superblock**, when equal to 1, indicates that superblocks contain
 128x128 luma samples. When equal to 0, it indicates that superblocks contain 64x64


### PR DESCRIPTION
There are no syntax elements named "frame_id" and "delta_frame_id". Change them to the intended syntax element names.