### PR TITLE
[Editorial] Fix index for RefFrameId

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -7276,7 +7276,7 @@ FeatureEnabled[ j ][ k ] and FeatureData[ j ][ k ] for j = 0 .. MAX_SEGMENTS-1, 
 This process is the reverse of the reference frame update process specified in [section 7.20][]. It loads saved values for a previous reference
 frame back into the current frame variables. The index of the saved reference frame to load is given by the syntax element frame_to_show_map_idx.
 
-  * current_frame_id is set equal to RefFrameId[ i ].
+  * current_frame_id is set equal to RefFrameId[ frame_to_show_map_idx ].
   
   * UpscaledWidth is set equal to RefUpscaledWidth[ frame_to_show_map_idx ].
   


### PR DESCRIPTION
Fix the index for the RefFrameId array in Section 7.21. Reference frame loading process.