### PR TITLE
Update 07.bitstream.semantics.md

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1342,12 +1342,12 @@ indicates that further processing is required.
 If obu_type is equal to OBU_FRAME, it is a requirement of bitstream conformance that show_existing_frame is equal to 0.
 
 **frame_to_show_map_idx** specifies the frame to be output. It is only
-available if show_existing_frame is 1.
+available if show_existing_frame is 1. It is a requirement of bitstream conformance that RefValid[ frame_to_show_map_idx ] is equal to 1.
 
 **display_frame_id** provides the frame id number for the frame to output.
 It is a requirement of bitstream conformance that whenever display_frame_id is read, the value matches RefFrameId[ frame_to_show_map_idx ]
 (the value of current_frame_id at the time that the frame indexed by
-frame_to_show_map_idx was stored), and that RefValid[ frame_to_show_map_idx ] is equal to 1.
+frame_to_show_map_idx was stored).
 
 It is a requirement of bitstream conformance that the number of bits needed to read display_frame_id
 does not exceed 16.  This is equivalent to the constraint that idLen <= 16.


### PR DESCRIPTION
This proposed change assumes the second interpretation that I described in https://crbug.com/aomedia/2295: RefValid[ frame_to_show_map_idx ] should be checked whenever frame_to_show_map_idx is read.