### PR TITLE
Update 07.bitstream.semantics.md

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1347,7 +1347,7 @@ available if show_existing_frame is 1.
 **display_frame_id** provides the frame id number for the frame to output.
 It is a requirement of bitstream conformance that whenever display_frame_id is read, the value matches RefFrameId[ frame_to_show_map_idx ]
 (the value of current_frame_id at the time that the frame indexed by
-frame_to_show_map_idx was stored), and that RefValid[ frame_to_show_map_idx ] is equal to 1.
+frame_to_show_map_idx was stored) and RefValid[ frame_to_show_map_idx ] is equal to 1.
 
 It is a requirement of bitstream conformance that the number of bits needed to read display_frame_id
 does not exceed 16.  This is equivalent to the constraint that idLen <= 16.
@@ -1488,8 +1488,7 @@ When this function is called, the set frame refs
 process specified in [section 7.8][] is invoked.
 
 **ref_frame_idx[ i ]** specifies which reference frames are used by inter frames. It
-is a requirement of bitstream conformance that RefValid[ ref_frame_idx[ i ] ] is equal
-to 1, and that the selected reference frames match the current frame in bit depth,
+is a requirement of bitstream conformance that the selected reference frames match the current frame in bit depth,
 profile, chroma subsampling, and color space.
 
 **Note:** Syntax elements indicate a reference (such as LAST_FRAME, ALTREF_FRAME).
@@ -1520,7 +1519,8 @@ reference. It is a requirement of bitstream conformance that whenever
 expectedFrameId[ i ] is calculated, the value matches
 RefFrameId[ ref_frame_idx[ i ] ]
 (this contains the value of current_frame_id at the time that the frame indexed
-by ref_frame_idx was stored).
+by ref_frame_idx was stored) and RefValid[ ref_frame_idx[ i ] ] is equal
+to 1.
 
 **allow_high_precision_mv** equal to 0 specifies that motion vectors are
 specified to quarter pel precision; allow_high_precision_mv equal to 1


### PR DESCRIPTION
Clarify that we should check RefValid only when we check display_frame_id and expectedFrameId[ i ]. See https://crbug.com/aomedia/2295.

This matches the libaom reference code in av1/decoder/decodeframe.c:

```
static int read_uncompressed_header(AV1Decoder *pbi,
                                    struct aom_read_bit_buffer *rb) {
...
      if (seq_params->frame_id_numbers_present_flag) {
        int frame_id_length = seq_params->frame_id_length;
        int display_frame_id = aom_rb_read_literal(rb, frame_id_length);
        /* Compare display_frame_id with ref_frame_id and check valid for
         * referencing */
        if (display_frame_id != cm->ref_frame_id[existing_frame_idx] ||
            cm->valid_for_referencing[existing_frame_idx] == 0)
          aom_internal_error(&cm->error, AOM_CODEC_CORRUPT_FRAME,
                             "Reference buffer frame ID mismatch");
      }
...
        if (seq_params->frame_id_numbers_present_flag) {
          int frame_id_length = seq_params->frame_id_length;
          int diff_len = seq_params->delta_frame_id_length;
          int delta_frame_id_minus_1 = aom_rb_read_literal(rb, diff_len);
          int ref_frame_id =
              ((cm->current_frame_id - (delta_frame_id_minus_1 + 1) +
                (1 << frame_id_length)) %
               (1 << frame_id_length));
          // Compare values derived from delta_frame_id_minus_1 and
          // refresh_frame_flags. Also, check valid for referencing
          if (ref_frame_id != cm->ref_frame_id[ref] ||
              cm->valid_for_referencing[ref] == 0)
            aom_internal_error(&cm->error, AOM_CODEC_CORRUPT_FRAME,
                               "Reference buffer frame ID mismatch");
        }
```