### PR TITLE
Update 06.bitstream.syntax.md

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -934,8 +934,7 @@ two order hints by sign extending the result of subtracting the values.
 |     for ( i = 0; i < REFS_PER_FRAME; i++ ) {              |
 |         @@found_ref                                       | f(1)
 |         if ( found_ref == 1 ) {
-|             UpscaledWidth = RefUpscaledWidth[ ref_frame_idx[ i ] ]
-|             FrameWidth = UpscaledWidth
+|             FrameWidth = RefUpscaledWidth[ ref_frame_idx[ i ] ]
 |             FrameHeight = RefFrameHeight[ ref_frame_idx[ i ] ]
 |             RenderWidth = RefRenderWidth[ ref_frame_idx[ i ] ]
 |             RenderHeight = RefRenderHeight[ ref_frame_idx[ i ] ]


### PR DESCRIPTION
In frame_size_with_refs( ), inside the for loop, if found_ref is equal to 1, we don't need to set the UpscaledWidth variable, because it will be immediately overwritten by the superres_params() call after the for loop.

Note: The current text is correct. This is just a cleanup. Please feel free to reject this.