### PR TITLE
Update 07.bitstream.semantics.md

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1992,7 +1992,7 @@ element loop_filter_mode_deltas is present; update_mode_delta equal to 0 means t
 this syntax element is not present.
 
 **loop_filter_mode_deltas** contains the adjustment needed for the filter level
-based on the chosen mode. If this syntax element is not present in the,
+based on the chosen mode. If this syntax element is not present,
 it maintains its previous value.
 
 **Note:** The previous values for loop_filter_mode_deltas and


### PR DESCRIPTION
Remove "in the" after "is not present".

We could also fix this by adding "bitstream" after "in the", but I think removing "in the" fits in better with the text around it.