### PR TITLE
[Editorial] Do not clear GmType in setup_past_independence

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1572,8 +1572,6 @@ is invoked the following takes place:
   * PrevSegmentIds[ row ][ col ] is set equal to 0 for row = 0..MiRows-1 and
     col = 0..MiCols-1.
 
-  * GmType[ ref ] is set equal to IDENTITY for ref = LAST_FRAME..ALTREF_FRAME.
-
   * PrevGmParams[ ref ][ i ] is set equal to ( ( i % 3 == 2 ) ? 1 \<\< WARPEDMODEL_PREC_BITS : 0 )
     for ref = LAST_FRAME..ALTREF_FRAME, for i = 0..5.
 


### PR DESCRIPTION
setup_past_independence() does not need to set GmType[ ref ] to IDENTITY.

See https://crbug.com/aomedia/2301. Although it is harmless to set a field unnecessarily, it may mislead someone who is trying to analyze the spec. I propose we remove this line to avoid potential misunderstanding during spec analysis.