### PR TITLE
Update 09.parsing.process.md

### DIFF
--- a/09.parsing.process.md
+++ b/09.parsing.process.md
@@ -66,8 +66,8 @@ have been used in the symbol decoding process.  These padding zero bits are not 
 The array TileIntraFrameYModeCdf is set equal to a copy of Default_Intra_Frame_Y_Mode_Cdf.
 
 A copy is made of each of the CDF arrays mentioned in the semantics for
-init_coeff_cdfs and init_non_coeff_cdfs. The name of the copy is the name of the CDF array
-prefixed with "Tile".  This copying produces the following arrays:
+init_coeff_cdfs and init_non_coeff_cdfs.  The name of the destination for the copy is the name of the CDF array
+prefixed with "Tile".  The name of the source for the copy is the name of the CDF array with no prefix.  This copying produces the following arrays:
 
   * TileYModeCdf
 


### PR DESCRIPTION
Explicitly state the destination and the source for the copy of the CDF arrays in the "Initialization process for symbol decoder" section.

This more verbose format is used in the specifications of the other copies of the CDF arrays.