### PR TITLE
[Editorial] Do not initialize feature_value in segmentation_params

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -1120,7 +1120,6 @@ two order hints by sign extending the result of subtracting the values.
 |         if ( segmentation_update_data == 1 ) {            |
 |             for ( i = 0; i < MAX_SEGMENTS; i++ ) {        |
 |                 for ( j = 0; j < SEG_LVL_MAX; j++ ) {     |
-|                     feature_value = 0                     |
 |                     @@feature_enabled                     | f(1)
 |                     FeatureEnabled[ i ][ j ] = feature_enabled
 |                     clippedValue = 0


### PR DESCRIPTION
segmentation_params() does  not need to initialize feature_value to 0, because feature_value is always read from the bitstream before it is used (to compute clippedValue).