### PR TITLE
Correct #temporal, #spatial layers in predefined scalability modes

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -660,8 +660,8 @@ of the bitstream:
 The preconfigured modes are described below.  The mechanism for describing alternative structures is
 described in scalability_structure() below.
 
-All predefined modes follow a dyadic, hierarchical picture prediction structure.  They support up to three
-temporal layers, in combinations with one or two spatial layers.  The second spatial layer may have
+All predefined modes follow a dyadic, hierarchical picture prediction structure.  They support up to seven
+temporal layers, in combinations with up to four spatial layers.  The second spatial layer may have
 twice or one and a half times the resolution of the base layer in each dimension, depending on the mode.
 There is also support for a spatial layer that uses no inter-layer prediction (i.e., the second spatial
 layer does not use its corresponding base layer as a reference) and a spatial layer that uses inter-layer prediction only at key frames.


### PR DESCRIPTION
The predefined modes define up to 7 temporal and 4 spatial layers. The text says 3 and 2, respectively.