### PR TITLE
Update 06.bitstream.syntax.md

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -2791,11 +2791,9 @@ needs_interp_filter( ) {
 |                 sbSize = use_128x128_superblock ? BLOCK_128X128 : BLOCK_64X64
 |                 sbSize4 = Num_4x4_Blocks_High[ sbSize ]
 |                 if ( MiRow - sbSize4 < MiRowStart ) {
-|                     PredMv[ 0 ][ 0 ] = 0
 |                     PredMv[ 0 ][ 1 ] = -(sbSize4 * MI_SIZE + INTRABC_DELAY_PIXELS) * 8
 |                 } else {
 |                     PredMv[ 0 ][ 0 ] = -(sbSize4 * MI_SIZE * 8)
-|                     PredMv[ 0 ][ 1 ] = 0
 |                 }
 |             }
 |         } else if ( compMode == GLOBALMV ) {


### PR DESCRIPTION
Don't need to set PredMv[ 0 ][ 0 ] or PredMv[ 0 ][ 1 ] equal to 0. They are already 0 inside the "if ( PredMv[ 0 ][ 0 ] == 0 && PredMv[ 0 ][ 1 ] == 0 )" block.