### PR TITLE
Update 07.bitstream.semantics.md

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2392,7 +2392,7 @@ backward prediction is when a frame is used that has not yet been output.)
 
 **reference_select** equal to 1 specifies that the mode info for inter blocks
 contains the syntax element comp_mode that indicates whether to use single or
-compound reference prediction. Reference_select equal to 0 specifies that all
+compound reference prediction. reference_select equal to 0 specifies that all
 inter blocks will use single prediction.
 
 #### Temporal point info semantics


### PR DESCRIPTION
Do not capitalize the syntax element name "reference_select", even when it appears at the beginning of a sentence. This is the style used in the spec.