### PR TITLE
Update 02.terms.md

### DIFF
--- a/02.terms.md
+++ b/02.terms.md
@@ -289,9 +289,8 @@ Sample value
 
 Segmentation map
 
-: A 3-bit number containing the segment affiliation for each 4x4 block in the
-  image. A segmentation map is stored for each reference frame to allow new
-  frames to use a previously coded map.
+: One 3-bit number per 4x4 block in the frame specifying the segment affiliation of that block.
+  A segmentation map is stored for each reference frame to allow new frames to use a previously coded map.
 
 Sequence
 


### PR DESCRIPTION
Make it clear that the segmentation map specifies a segment affiliation for each 4x4 block in the frame.