### PR TITLE
[Editorial] Remove invalid note about tile dependency

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2590,10 +2590,6 @@ Variable **AvailL** is equal to 0 if the information from the block to the left
 can not be used on the luma plane; AvailL is equal to 1 if the information from
 the block to the left can be used on the luma plane.
 
-**Note:** Information from a block in a different tile can be used in some
-circumstances if the block is above, but not if the block is to the left.
-{:.alert .alert-info }
-
 Variables **AvailUChroma** and **AvailLChroma** have the same significance
 as AvailU and AvailL, but on the chroma planes.
 


### PR DESCRIPTION
VP9 allowed information to be used from the tile above.
This has been corrected in AV1 so the note is no longer needed.