### PR TITLE
[Editorial] No need for clipping, this value is 95

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -4291,8 +4291,7 @@ count_units_in_frame(unitSize, frameSize) {
 |             } else {
 |               v = 0
 |               if ( i == 1 ) {
-|                 v = Clip3( min, max, (1 \<\< SGRPROJ_PRJ_BITS) -
-|                            RefSgrXqd[ plane ][ 0 ] )
+|                 v = 95
 |               }
 |             }
 |             LrSgrXqd[ plane ][ unitRow ][ unitCol ][ i ] = v


### PR DESCRIPTION
It was found by Christopher "Monty" Montgomery that when a value
between 96 and 224 is clipped between -32 and 95, the resulting
value will always be 95.