### PR TITLE
Merge for loops in reference frame update process

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -7214,6 +7214,8 @@ if (refresh_frame_flags \>\> i) & 1 is equal to 1):
 
   * RefBitDepth[ i ] is set equal to BitDepth.
 
+  * RefOrderHint[ i ] is set equal to OrderHint.
+
   * SavedOrderHints[ i ][ j + LAST_FRAME ] is set equal to OrderHints[ j + LAST_FRAME ] for j = 0..REFS_PER_FRAME-1.
 
   * FrameStore[ i ][ 0 ][ y ][ x ] is set equal to LrFrame[ 0 ][ y ][ x ]
@@ -7245,12 +7247,6 @@ if (refresh_frame_flags \>\> i) & 1 is equal to 1):
   * The function save_loop_filter_params( i ) is invoked (see below).
 
   * The function save_segmentation_params( i ) is invoked (see below).
-
-For each value of i from 0 to NUM_REF_FRAMES - 1, the following applies
-if bit i of refresh_frame_flags is equal to 1 (i.e.
-if (refresh_frame_flags \>\> i) & 1 is equal to 1):
-
-  * RefOrderHint[ i ] is set equal to OrderHint.
 
 save_cdfs( ctx ) is a function call that indicates that all the CDF arrays are saved into frame context number ctx in the range 0 to (NUM_REF_FRAMES - 1).
 When this function is invoked the following takes place:


### PR DESCRIPTION
The two for loops in the reference frame update process do not have any dependency between them and therefore can be merged.