### PR TITLE
OBU ordering clarification

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -391,7 +391,7 @@ then all frame headers and tile group OBUs associated with base (spatial_id equa
 enhancement layer (spatial_id greater than 0 or temporal_id greater than 0) data must include the OBU extension header.
 
 OBUs with obu_extension_flag equal to 1 must appear within a temporal unit in
-increasing order of spatial_id values.
+non-decreasing order of spatial_id values.
 
 The first temporal unit of a coded video sequence must contain one or more sequence header OBUs before the first frame header OBU.
 

--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -390,8 +390,8 @@ or temporal_id greater than 0)
 then all frame headers and tile group OBUs associated with base (spatial_id equals 0 and temporal_id equals 0) and
 enhancement layer (spatial_id greater than 0 or temporal_id greater than 0) data must include the OBU extension header.
 
-OBUs with spatial level IDs (spatial_id) greater than 0 must appear within a temporal unit in
-increasing order of the spatial level ID values.
+OBUs with obu_extension_flag equal to 1 must appear within a temporal unit in
+increasing order of spatial_id values.
 
 The first temporal unit of a coded video sequence must contain one or more sequence header OBUs before the first frame header OBU.
 


### PR DESCRIPTION
The current text appears to allow base layer (spatial_id equal to 0) OBUs to follow enhancement layer OBUs.