### PR TITLE
Remove "n-bit" from the description of uvlc().

### DIFF
--- a/04.conventions.md
+++ b/04.conventions.md
@@ -339,7 +339,7 @@ invoked and the syntax element is set equal to the return value.
 
 #### uvlc()
 
-Variable length unsigned n-bit number appearing directly in the bitstream.
+Variable length unsigned number appearing directly in the bitstream.
 The parsing process for this descriptor is specified below:
 
 | --------------------------------------------------------- | ---------------- |


### PR DESCRIPTION
"n-bit" implies a fixed length, so it contradicts "Variable length" in the description. Also, the variable 'n' does not appear in the description of uvlc().