### PR TITLE
Correct start_decode_at_removal_time

### DIFF
--- a/annex.e.decoder.model.md
+++ b/annex.e.decoder.model.md
@@ -544,12 +544,11 @@ they are no longer required for decode or display.
 start_decode_at_removal_time( removal ) {
     for ( i = 0; i < BUFFER_POOL_MAX_SIZE; i++ ) {
         if ( PlayerRefCount[ i ] > 0) {
-            if ( PresentationTimes[ i ] < removal ) {
+            if ( PresentationTimes[ i ] <= removal ) {
                  PlayerRefCount[ i ] = 0
                  if ( DecoderRefCount[ i ] == 0 )
                      free_buffer( i )
             }
-            break
         }
     }
     return removal


### PR DESCRIPTION
The decoder model tracks which reference frames can be freed.
This correction ensures that all relevant frames are freed instead of just checking the first one. 

BUG=aomedia:2370