### PR TITLE
Minimum reference buffer downscale should be 2 not 16

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1913,8 +1913,8 @@ the range 0..(REFS_PER_FRAME - 1), all the following conditions are true:
 
   * 2 * FrameWidth >= RefUpscaledWidth[ ref_frame_idx[ i ] ]
   * 2 * FrameHeight >= RefFrameHeight[ ref_frame_idx[ i ] ]
-  * FrameWidth <= 16 * RefUpscaledWidth[ ref_frame_idx[ i ] ]
-  * FrameHeight <= 16 * RefFrameHeight[ ref_frame_idx[ i ] ]
+  * FrameWidth <= 2 * RefUpscaledWidth[ ref_frame_idx[ i ] ]
+  * FrameHeight <= 2 * RefFrameHeight[ ref_frame_idx[ i ] ]
 
 **Note:** This is a requirement even if all the blocks in an inter frame are
 coded using intra prediction.


### PR DESCRIPTION
Reference buffer scaling should only be expected to support scaling factors in the range 0.5 - 2.0.

The current text incorrectly states the range as 0.5 - 16, which it was for VP9.