### PR TITLE
[Editorial] remove mask blend 4:4:0 condition

### DIFF
--- a/08.decoding.process.md
+++ b/08.decoding.process.md
@@ -4076,8 +4076,6 @@ for ( y = 0; y < h; y++ ) {
             m = Mask[ y ][ x ]
         } else if ( subX && !subY ) {
             m = Round2( Mask[ y ][ 2*x ] + Mask[ y ][ 2*x+1 ], 1 )
-        } else if ( !subX && subY ) {
-            m = Round2( Mask[ 2*y ][ x ] + Mask[ 2*y+1 ][ x ], 1 )
         } else {
             m = Round2( Mask[ 2*y ][ 2*x ] + Mask[ 2*y ][ 2*x+1 ] +
                 Mask[ 2*y+1 ][ 2*x ] + Mask[ 2*y+1 ][ 2*x+1 ], 2 )


### PR DESCRIPTION
subsampling_x = 0 and subsampling_y = 1 corresponds to 4:4:0, this is a left over from vp9.
https://crbug.com/aomedia/2399