### PR TITLE
Simplify CeilLog2(x).

### DIFF
--- a/04.conventions.md
+++ b/04.conventions.md
@@ -176,10 +176,8 @@ following section) is:
 
 ~~~~~ c
 CeilLog2( x ) {
-  if ( x < 2 )
-    return 0
-  i = 1
-  p = 2
+  i = 0
+  p = 1
   while ( p < x ) {
     i++
     p = p << 1


### PR DESCRIPTION
The new code works for all x >= 0. It does not need the special case for x < 2.