### PR TITLE
all_zero cdf ctx: No need to clamp top  and left

### DIFF
--- a/09.parsing.process.md
+++ b/09.parsing.process.md
@@ -952,8 +952,6 @@ if ( plane == 0 ) {
         if ( y4 + k < maxY4 )
             left = Max( left, LeftLevelContext[ plane ][ y4 + k ] )
     }
-    top = Min( top, 255 )
-    left = Min( left, 255 )
     if ( bw == w && bh == h ) {
         ctx = 0
     } else if ( top == 0 && left == 0 ) {


### PR DESCRIPTION
My colleague Vignesh Venkatasubramanian suggested this change.

In the procedure for computing the 'ctx' variable for the all_zero cdf, the following two lines can be omitted:

        top = Min( top, 255 )
        left = Min( left, 255 )

'top' and 'left' are the maximum of AboveLevelContext[ plane ][ x4 + k ] and LeftLevelContext[ plane ][ y4 + k ], respectively. The value we store in AboveLevelContext and LeftLevelContext are less than or equal to 63, because of the following line in the coeffs( plane, startX, startY, txSz ) function in Section 5.11.39:

        culLevel = Min( 63, culLevel )