### PR TITLE
[Editorial] grain_scaling_minus_8 semantics

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2303,8 +2303,8 @@ If i is greater than 0, it is a requirement of bitstream conformance that point_
 **point_cr_scaling[ i ]** represents the scaling (output) value for the i-th point of the piecewise
 linear scaling function for cr component.
 
-**grain_scaling_minus_8** represents the shift – 8 applied to the values of the chroma
-component. The grain_scaling_minus_8 can take values of 0..3 and determines the
+**grain_scaling_minus_8** represents a shift – 8 applied during film grain synthesis.
+The grain_scaling_minus_8 can take values of 0..3 and determines the
 range and quantization step of the standard deviation of film grain.
 
 **ar_coeff_lag** specifies the number of auto-regressive coefficients for


### PR DESCRIPTION
grain_scaling_minus_8 is used during film grain synthesis for both luma and chroma, so correct description that used to say it only applied to chroma.