### PR TITLE
Add additional non-uniform/explicit tile details.

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -2167,6 +2167,10 @@ for each tile down the image.
 
 **maxTileHeightSb** specifies the maximum height (in units of superblocks) that can be used for a tile (to avoid making tiles with too much area).
 
+**Note:** If uniform_tile_spacing_flag is equal to 0, the maximum height for a tile is calculated such that the widest tile has a maximum area of one half
+the uniform tile area limit MAX_TILE_AREA. This is to compensate for difficult parallelization scaling for unbalanced tile sizing.
+{:.alert .alert-info }
+
 **context_update_tile_id** specifies which tile to use for the CDF update.
 It is a requirement of bitstream conformance that context_update_tile_id is less than TileCols * TileRows.
 


### PR DESCRIPTION
Add explanation for MaxTileHeightSb limits when non-uniform/explicit tiles are used.
Based on discussion from:
https://bugs.chromium.org/p/aomedia/issues/detail?id=2559&q=