### PR TITLE
Change "1 fewer bits" to "1 fewer bit" (singular)

### DIFF
--- a/04.conventions.md
+++ b/04.conventions.md
@@ -459,7 +459,7 @@ Unsigned encoded integer with maximum number of values n (i.e. output in range
 0..n-1).
 
 This descriptor is similar to f(CeilLog2(n)), but reduces wastage incurred
-when encoding non-power of two value ranges by encoding 1 fewer bits for the
+when encoding non-power of two value ranges by encoding 1 fewer bit for the
 lower part of the value range. For example, when n is equal to 5, the encodings
 are as follows (full binary encodings are also presented for comparison):
 


### PR DESCRIPTION
"1 fewer bit" seems grammatically more correct, but the Google search engine found more results for "one fewer bits" than "one fewer bit". So please feel free to reject this change.