### PR TITLE
Correct informative table of some scalability mode in 07. semantics

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -854,7 +854,7 @@ structure in the scalability structure data must be for the highest frame rate l
 
 **temporal_group_temporal_switching_up_point_flag[ i ]** is set to 1 if subsequent (in decoding order) pictures with
 a temporal_id higher than temporal_group_temporal_id[ i ] do not depend on any picture preceding the
-current picture (in coding order) with temporal_id higher than temporal_group_temporal_id[ i ].
+current picture (in decoding order) with temporal_id higher than temporal_group_temporal_id[ i ].
 
 **Note:** This condition ensures that switching up to a higher frame rate is possible at the current
 picture.
@@ -898,7 +898,7 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_temporal_switching_up_point_flag[1] | 1
 |  | temporal_group_spatial_switching_up_point_flag[1] | 0
 |  | temporal_group_ref_cnt[1] | 1
-|  |     temporal_group_ref_pic_diff[0][0] | 1
+|  |     temporal_group_ref_pic_diff[1][0] | 1
 {:.table .table-sm .table-bordered }
 
 ##### L1T3 (Informative)
@@ -920,12 +920,13 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_ref_cnt[1] | 1
 |  |     temporal_group_ref_pic_diff[1][0] | 1
 | 2 | temporal_group_temporal_id[2] | 1
-|  | temporal_group_temporal_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[2] | 1
+|  | temporal_group_spatial_switching_up_point_flag[2] | 0
 |  | temporal_group_ref_cnt[2] | 1
 |  |     temporal_group_ref_pic_diff[2][0] | 2
 | 3 | temporal_group_temporal_id[3] | 2
-|  | temporal_group_temporal_switching_up_point_flag[1] | 1
-|  | temporal_group_spatial_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[3] | 1
+|  | temporal_group_spatial_switching_up_point_flag[3] | 0
 |  | temporal_group_ref_cnt[3] | 1
 |  |     temporal_group_ref_pic_diff[3][0] | 1
 {:.table .table-sm .table-bordered }
@@ -936,7 +937,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
+| 1 | spatial_layer_ref_id[1] | 0
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
@@ -953,7 +954,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
+| 1 | spatial_layer_ref_id[1] | 0
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
@@ -975,7 +976,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
+| 1 | spatial_layer_ref_id[1] | 0
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
@@ -990,12 +991,13 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_ref_cnt[1] | 1
 |  |     temporal_group_ref_pic_diff[1][0] | 1
 | 2 | temporal_group_temporal_id[2] | 1
-|  | temporal_group_temporal_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[2] | 1
+|  | temporal_group_spatial_switching_up_point_flag[2] | 0
 |  | temporal_group_ref_cnt[2] | 1
 |  |     temporal_group_ref_pic_diff[2][0] | 2
 | 3 | temporal_group_temporal_id[3] | 2
-|  | temporal_group_temporal_switching_up_point_flag[1] | 1
-|  | temporal_group_spatial_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[3] | 1
+|  | temporal_group_spatial_switching_up_point_flag[3] | 0
 |  | temporal_group_ref_cnt[3] | 1
 |  |     temporal_group_ref_pic_diff[3][0] | 1
 {:.table .table-sm .table-bordered }
@@ -1006,7 +1008,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
@@ -1023,7 +1025,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
@@ -1045,7 +1047,7 @@ be described using temporal group description syntax and are not described in th
 | **Layer** | **Spatial Layers Description**  | **Value**
 |  | spatial_layers_cnt_minus_1 | 1
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
@@ -1060,12 +1062,13 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_ref_cnt[1] | 1
 |  |     temporal_group_ref_pic_diff[1][0] | 1
 | 2 | temporal_group_temporal_id[2] | 1
-|  | temporal_group_temporal_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[2] | 1
+|  | temporal_group_spatial_switching_up_point_flag[2] | 0
 |  | temporal_group_ref_cnt[2] | 1
 |  |     temporal_group_ref_pic_diff[2][0] | 2
 | 3 | temporal_group_temporal_id[3] | 2
-|  | temporal_group_temporal_switching_up_point_flag[1] | 1
-|  | temporal_group_spatial_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[3] | 1
+|  | temporal_group_spatial_switching_up_point_flag[3] | 0
 |  | temporal_group_ref_cnt[3] | 1
 |  |     temporal_group_ref_pic_diff[3][0] | 1
 {:.table .table-sm .table-bordered }
@@ -1074,11 +1077,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
-| 2 |  spatial_layer_ref_id[1] | 1
-
+| 1 | spatial_layer_ref_id[1] | 0
+| 2 | spatial_layer_ref_id[2] | 1
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 1
@@ -1093,10 +1095,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
-| 2 |  spatial_layer_ref_id[1] | 1
+| 1 | spatial_layer_ref_id[1] | 0
+| 2 | spatial_layer_ref_id[2] | 1
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
@@ -1116,10 +1118,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 0
-| 2 |  spatial_layer_ref_id[1] | 1
+| 1 | spatial_layer_ref_id[1] | 0
+| 2 | spatial_layer_ref_id[2] | 1
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
@@ -1134,12 +1136,13 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_ref_cnt[1] | 1
 |  |     temporal_group_ref_pic_diff[1][0] | 1
 | 2 | temporal_group_temporal_id[2] | 1
-|  | temporal_group_temporal_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[2] | 1
+|  | temporal_group_spatial_switching_up_point_flag[2] | 0
 |  | temporal_group_ref_cnt[2] | 1
 |  |     temporal_group_ref_pic_diff[2][0] | 2
 | 3 | temporal_group_temporal_id[3] | 2
-|  | temporal_group_temporal_switching_up_point_flag[1] | 1
-|  | temporal_group_spatial_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[3] | 1
+|  | temporal_group_spatial_switching_up_point_flag[3] | 0
 |  | temporal_group_ref_cnt[3] | 1
 |  |     temporal_group_ref_pic_diff[3][0] | 1
 {:.table .table-sm .table-bordered }
@@ -1148,10 +1151,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
-| 2 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
+| 2 | spatial_layer_ref_id[2] | 255
 
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
@@ -1167,10 +1170,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
-| 2 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
+| 2 | spatial_layer_ref_id[1] | 255
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 2
@@ -1190,10 +1193,10 @@ be described using temporal group description syntax and are not described in th
 
 | ----------- | ------------------------------------------------ | ---------------- |
 | **Layer** | **Spatial Layers Description**  | **Value**
-|  | spatial_layers_cnt_minus_1 | 1
+|  | spatial_layers_cnt_minus_1 | 2
 | 0 | spatial_layer_ref_id[0] | 255
-| 1 |  spatial_layer_ref_id[1] | 255
-| 2 |  spatial_layer_ref_id[1] | 255
+| 1 | spatial_layer_ref_id[1] | 255
+| 2 | spatial_layer_ref_id[1] | 255
 |  |  |
 | **Picture** | **Temporal Group Description**  | **Value**
 |  | temporal_group_size | 4
@@ -1208,12 +1211,13 @@ be described using temporal group description syntax and are not described in th
 |  | temporal_group_ref_cnt[1] | 1
 |  |     temporal_group_ref_pic_diff[1][0] | 1
 | 2 | temporal_group_temporal_id[2] | 1
-|  | temporal_group_temporal_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[2] | 1
+|  | temporal_group_spatial_switching_up_point_flag[2] | 0
 |  | temporal_group_ref_cnt[2] | 1
 |  |     temporal_group_ref_pic_diff[2][0] | 2
 | 3 | temporal_group_temporal_id[3] | 2
-|  | temporal_group_temporal_switching_up_point_flag[1] | 1
-|  | temporal_group_spatial_switching_up_point_flag[1] | 0
+|  | temporal_group_temporal_switching_up_point_flag[3] | 1
+|  | temporal_group_spatial_switching_up_point_flag[3] | 0
 |  | temporal_group_ref_cnt[3] | 1
 |  |     temporal_group_ref_pic_diff[3][0] | 1
 {:.table .table-sm .table-bordered }


### PR DESCRIPTION
I'm not sure how to treat `temporal_group_spatial_switching_up_point_flag[i]`, but I think that it may work.
I'd appreciate it if some person would confirm my P.R. :)

- Correct miss type description in `temporal_group_temporal_switching_up_point_flag[i]
- Correct some wrong index in informative table of some scalability mode
- Insert some `temporal_group_spatial_switching_up_point_flag[i]` rows in some table which missed