### PR TITLE
HTTP => HTTPS for bundler.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ development, the canonical spec will likely be served as HTML, not PDF.
 [kramdown]: https://kramdown.gettalong.org/
 [Jekyll]: https://jekyllrb.com/
 [rbenv]: https://github.com/rbenv/rbenv
-[bundler]: http://bundler.io/
+[bundler]: https://bundler.io/
 [install rbenv]: https://github.com/rbenv/rbenv#installation
 [GruntJS]: https://gruntjs.com/
 [NodeJS]: https://nodejs.org/


### PR DESCRIPTION
Checked http://bundler.io/, skipping the redirect HTTP => HTTPS this way 0:-)