### PR TITLE
Update uvlc definition to match implementations

### DIFF
--- a/04.conventions.md
+++ b/04.conventions.md
@@ -345,14 +345,14 @@ The parsing process for this descriptor is specified below:
 | --------------------------------------------------------- | ---------------- |
 | uvlc() {                                                  | **Type**
 |     leadingZeros = 0                                      |
-|     while ( 1 ) {                                          |
+|     while ( leadingZeros \< 32 ) {                        |
 |         @@done                                            | f(1)
 |         if ( done )                                       |
 |             break                                         |
 |         leadingZeros++                                    |
 |     }                                                     |
-|     if ( leadingZeros >\= 32 ) {                           |
-|         return ( 1 \<\< 32 ) - 1                            |
+|     if ( leadingZeros \=\= 32 ) {                         |
+|         return ( 1 \<\< 32 ) - 1                          |
 |     }                                                     |
 |     @@value                                               | f(leadingZeros)
 |     return value + ( 1 \<\< leadingZeros ) - 1


### PR DESCRIPTION
The specified uvlc parsing process does not match that used by the libaom reference implementation [1].  The specification encodes 2^32-1 as at least thirty-two zero bits followed by a one, while libaom uses exactly thirty-two zero bits without a one.  Other implementations also do not match the specification here ([2] matches the libaom behaviour, [3] raises an error if it sees this case).

The difference is never encountered in conforming streams because the one syntax element using the uvlc parsing process
(`num_ticks_per_picture_minus_1`) is not allowed to take the maximum value of 2^32-1.  Given that this area is therefore not covered for conformance purposes, it seems easier to update the text of the specification to match the existing implementations than to do the reverse.

[1] <https://aomedia.googlesource.com/aom/+/refs/heads/main/aom_dsp/bitreader_buffer.c>, line 63.

[2] <https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Source/Lib/Decoder/Codec/EbDecBitstream.c?ref_type=heads#L68>

[3] <https://chromium.googlesource.com/codecs/libgav1/+/refs/heads/main/src/utils/raw_bit_reader.cc>, line 161.