### PR TITLE
Add cropping metadata

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -427,6 +427,8 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |         metadata_scalability( )
 |     else if ( metadata_type == METADATA_TYPE_TIMECODE )
 |         metadata_timecode( )
+|     else if ( metadata_type == METADATA_TYPE_CROP )
+|         metadata_crop( )
 | }
 {:.syntax }
 
@@ -568,6 +570,23 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 |     @@time_offset_length                                  | f(5)
 |     if ( time_offset_length > 0 ) {
 |         @@time_offset_value                               | f(time_offset_length)
+|     }
+| }
+{:.syntax }
+
+#### Metadata cropping syntax
+
+| --------------------------------------------------------- | ---------------- |
+| metadata_crop( ) {                                        | **Type**
+|     @@crop_width_minus_1                                  | f(16)
+|     @@crop_height_minus_1                                 | f(16)
+|     @@crop_offset_present                                 | f(1)
+|     if ( crop_offset_present == 1 ) {
+|         @@crop_x_offset                                   | f(16)
+|         @@crop_y_offset                                   | f(16)
+|     } else {
+|         crop_x_offset = 0
+|         crop_y_offset = 0
 |     }
 | }
 {:.syntax }

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1318,19 +1318,20 @@ time_offset_value is not present, its value is inferred to be equal to 0.
 #### Metadata crop semantics
 
 When present the metadata_crop OBU applies starting at the next frame in the sequence 
-with matching temporal_id and spatial_id, and shall apply to all matching frames until the next Key Frame
-or metadata_crop OBU. The output picture should be cropped to the region as specified in the 
-cropping metadata OBU. When applied, the crop shall be after all normal decode operations as a 
-post-processing step (after film grain synthesis in the output process).  This metadata has no 
-effect on the decoding process.
+with matching temporal_id and spatial_id, and shall apply to all frames with a matching 
+temporal_id and spatial_id until the next Key Frame or metadata_crop OBU. If no extension
+header is present the metadata_crop OBU applies to all layers.  The output 
+picture should be cropped to the region as specified in the cropping metadata OBU. 
+The crop shall be applied after all normal decode operations as a post-processing step. 
+This metadata information has no effect on the decoding process.
+
+**crop_width_minus_1** specifies the number of pixel columns minus 1 which should be rendered after applying crop_x_offset.
+
+**crop_height_minus_1** specifies the number of pixel rows minus 1 which should be rendered after applying crop_y_offset.
 
 **crop_x_offset** specifies the minimum pixel column containing picture data which should be rendered.
 
 **crop_y_offset** specifies the minimum pixel row containing picture data which should be rendered.
-
-**crop_width_minus_1** specifies the number of pixel columns minus 1 which which should be rendered after applying crop_x_offset.
-
-**crop_height_minus_1** specifies the number of pixel rows minus 1 which which should be rendered after applying crop_y_offset.
 
 If RenderWidth or RenderHeight are present in the frame header, then render width and height 
 shall be applied after cropping. 
@@ -1345,10 +1346,7 @@ The crop area shall align with the chroma subsampling grid:
  * crop_x_offset and crop_width_minus_1 + 1 must both be a multiple of subsampling_x + 1.
  * crop_y_offset and crop_height_minus_1 + 1 must both be a multiple of subsampling_y + 1.
 
-When muxed into a container that supports signaling cropping information, this metadata should 
-be removed from the bitstream and included in the container’s signaling mechanism.  
-If both the container and bitstream signal cropping information, then the container’s cropping 
-information takes precedence.
+In cases where cropping information is present in both the bitstream and the delivery or container format, the latter should be preferred.
 
 ### Frame header OBU semantics
 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1318,10 +1318,11 @@ time_offset_value is not present, its value is inferred to be equal to 0.
 #### Metadata crop semantics
 
 When present the metadata_crop OBU applies starting at the next frame in the sequence 
-with matching temporal_id and spatial_id, and shall apply to all matching frames until the next Key Frame.
-The output picture should be cropped to the region as specified in the cropping metadata OBU.
-When applied, the crop shall be after all normal decode operations as a post-processing step
-(after film grain synthesis in the output process).  This metadata has no effect on the decoding process.
+with matching temporal_id and spatial_id, and shall apply to all matching frames until the next Key Frame
+or metadata_crop OBU. The output picture should be cropped to the region as specified in the 
+cropping metadata OBU. When applied, the crop shall be after all normal decode operations as a 
+post-processing step (after film grain synthesis in the output process).  This metadata has no 
+effect on the decoding process.
 
 **crop_x_offset** specifies the minimum pixel column containing picture data which should be rendered.
 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -575,7 +575,8 @@ Metadata OBUs may or may not have an OBU extension header. If there is no extens
 | 4              | METADATA_TYPE_ITUT_T35      | payload-specific
 | 5              | METADATA_TYPE_TIMECODE      | N
 | 6-31           | Unregistered user private   | -
-| 32 and greater | Reserved for AOM use        | -
+| 32             | METADATA_TYPE_CROP          | Y
+| 33 and greater | Reserved for AOM use        | -
 {:.table .table-sm .table-bordered }
 
 The semantics of the column “Layer-specific” and its values are defined in Section 6.2.2. 
@@ -1313,6 +1314,40 @@ coded video sequence.
 **time_offset_value** is used to compute clockTimestamp. The
 number of bits used to represent time_offset_value is equal to time_offset_length. When
 time_offset_value is not present, its value is inferred to be equal to 0.
+
+#### Metadata crop semantics
+
+When present the metadata_crop OBU applies starting at the next frame in the sequence 
+with matching temporal_id and spatial_id, and shall apply until the next metadata_crop OBU.
+The output picture should be cropped to the region as specified in the cropping metadata OBU.
+When applied, the crop shall be after all normal decode operations as a post-processing step
+(after film grain synthesis in the output process).  This metadata has no effect on the decoding process.
+
+**crop_x_offset** specifies the minimum pixel column containing picture data which should be rendered.
+
+**crop_y_offset** specifies the minimum pixel row containing picture data which should be rendered.
+
+**crop_width_minus_1** specifies the number of pixel columns minus 1 which which should be rendered after applying crop_x_offset.
+
+**crop_height_minus_1** specifies the number of pixel rows minus 1 which which should be rendered after applying crop_y_offset.
+
+If RenderWidth or RenderHeight are present in the frame header, then render width and height 
+shall be applied after cropping. 
+
+The total cropped area shall not exceed the frame size:
+
+ * crop_width_minus_1 + crop_x_offset shall be less than or equal to frame_width_minus_1.
+ * crop_height_minus_1 + crop_y_offset shall be less than or equal to frame_height_minus_1.
+
+The crop area shall align with the chroma subsampling grid:
+
+ * crop_x_offset and crop_width_minus_1 + 1 must both be a multiple of subsampling_x + 1.
+ * crop_y_offset and crop_height_minus_1 + 1 must both be a multiple of subsampling_y + 1.
+
+When muxed into a container that supports signaling cropping information, this metadata should 
+be removed from the bitstream and included in the container’s signaling mechanism.  
+If both the container and bitstream signal cropping information, then the container’s cropping 
+information takes precedence.
 
 ### Frame header OBU semantics
 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -1318,7 +1318,7 @@ time_offset_value is not present, its value is inferred to be equal to 0.
 #### Metadata crop semantics
 
 When present the metadata_crop OBU applies starting at the next frame in the sequence 
-with matching temporal_id and spatial_id, and shall apply until the next metadata_crop OBU.
+with matching temporal_id and spatial_id, and shall apply to all matching frames until the next Key Frame.
 The output picture should be cropped to the region as specified in the cropping metadata OBU.
 When applied, the crop shall be after all normal decode operations as a post-processing step
 (after film grain synthesis in the output process).  This metadata has no effect on the decoding process.


### PR DESCRIPTION
This adds cropping metadata as proposed in CWG-D038.  Accepted in the 10/10/2023 CWG meeting.
Most of the text is the same as the proposal document with some minor adjustments:
* Replaced "valid picture data" with "rendered"
* Clarified the scope of the metadata to be from "metadata_crop OBU to Keyframe and/or next metadata_crop OBU" instead of just "until next metadata_crop OBU"

