### PR TITLE
Downgrade two new requirements to recommendations

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -81,7 +81,7 @@ possible by preventing emulation of MPEG2 transport stream ids.
 Reserved units are for future use and shall be ignored by AV1 decoder.
 
 The column “Layer-specific” indicates if the corresponding OBU type is considered to be associated with
-a specific layer  ("Y"), or not ("N"). OBUs that are not layer-specific must have the obu_extension_flag set to 0. 
+a specific layer  ("Y"), or not ("N"). OBUs that are not layer-specific should have the obu_extension_flag set to 0.
 
 Metadata OBU types may or may not be layer-specific, depending on the metadata type. The table in Section 6.7.1 specifies which types of metadata OBUs are layer-specific and which are not.
 
@@ -195,7 +195,7 @@ It is a requirement of bitstream conformance that operating_point_idc[ i ] is no
 **Note:** This constraint means it is not allowed for two operating points to have the same value of operating_point_idc.
 {:.alert .alert-info }
 
-If operating_point_idc[ op ] is not equal to 0 for any value of op from 0 to operating_points_cnt_minus_1, it is a requirement of bitstream conformance that obu_extension_flag is equal to 1 for all layer-specific OBUs in the coded video sequence.
+If operating_point_idc[ op ] is not equal to 0 for any value of op from 0 to operating_points_cnt_minus_1, obu_extension_flag should be equal to 1 for all layer-specific OBUs in the coded video sequence.
 
 **seq_level_idx[ i ]** specifies the level that the coded video sequence conforms to when operating point i is selected.
 


### PR DESCRIPTION
For backward compatibility, downgrade the following two new requirements
in commit 86fb0ac

  OBUs that are not layer-specific must have the obu_extension_flag
  set to 0.

  ..., it is a requirement of bitstream conformance that
  obu_extension_flag is equal to 1 for all layer-specific OBUs in the
  coded video sequence.

to recommendations

  OBUs that are not layer-specific should have the obu_extension_flag
  set to 0.

  ..., obu_extension_flag should be equal to 1 for all layer-specific
  OBUs in the coded video sequence.